### PR TITLE
build: fix eslint setup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/craco.config.ts
+++ b/craco.config.ts
@@ -1,6 +1,9 @@
 import { resolve } from 'path';
 
 export default {
+  eslint: {
+    enable: false,
+  },
   webpack: {
     alias: {
       '@react': resolve(__dirname, 'src/react'),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,20 +1,131 @@
 import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
+import importPlugin from "eslint-plugin-import";
+import prettierConfig from "eslint-config-prettier";
+import prettierPlugin from "eslint-plugin-prettier";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import reactPlugin from "eslint-plugin-react";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
 
-/** @type {import('eslint').Linter.Config[]} */
 export default [
-  { languageOptions: { globals: globals.browser } },
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
   {
-    ...pluginReact.configs.flat.recommended,
+    ignores: [
+      "node_modules/",
+      "build/",
+      "dist/",
+      ".craco/",
+      "public/",
+      "eslint.config.mjs",
+      "craco.config.ts",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "src/**/*.spec.ts",
+      "src/**/*.spec.tsx",
+    ],
+  },
+  // Configuration for React code (src/react)
+  {
+    files: ["src/**/*.{js,jsx,ts,tsx}", "!src/server/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        project: "./tsconfig.json",
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      import: importPlugin,
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+      prettier: prettierPlugin,
+    },
     rules: {
-      ...pluginReact.configs.flat.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
+      ...tsPlugin.configs["eslint-recommended"].rules,
+      ...tsPlugin.configs["recommended-requiring-type-checking"]?.rules,
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      ...prettierConfig.rules,
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+      eqeqeq: "error",
+      "import/first": "error",
+      "import/no-duplicates": "error",
+      "no-unused-vars": "off",
+      "prettier/prettier": "warn",
+      "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
-      "indent": ["error", 2],
-      '@typescript-eslint/no-explicit-any': 'off',
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+      "import/resolver": {
+        typescript: {},
+      },
+    },
+  },
+  // Configuration for Server code (src/server)
+  {
+    files: ["src/server/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        project: "./tsconfig.server.json",
+      },
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      import: importPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...tsPlugin.configs["eslint-recommended"].rules,
+      ...tsPlugin.configs["recommended-requiring-type-checking"]?.rules,
+      ...prettierConfig.rules,
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+      eqeqeq: "error",
+      "import/first": "error",
+      "import/no-duplicates": "error",
+      "import/no-unresolved": "error",
+      "no-unused-vars": "off",
+      "prettier/prettier": "warn",
+    },
+    settings: {
+      "import/resolver": {
+        typescript: {
+          project: "./tsconfig.server.json",
+        },
+      },
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "react:build": "cross-env BUILD_PATH=dist/react craco build",
     "server:build": "tsc --project tsconfig.server.json && tsc-alias -p tsconfig.server.json && cp package.json dist/server/",
     "electron:dev": "nodemon --watch src/server --ext ts --exec \"yarn server:build && cross-env NODE_ENV=development electron ./dist/server/index.js --verbose\"",
-    "lint": "clear && eslint --config ./eslint.config.mjs src",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
+    "lint": "eslint --config ./eslint.config.mjs src --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint --config ./eslint.config.mjs src --ext .js,.jsx,.ts,.tsx --fix",
     "test": "craco test"
   },
   "dependencies": {
@@ -37,12 +39,11 @@
     "react-router-dom": "^7.1.1",
     "react-scripts": "5.0.1",
     "semver": "^7.7.1",
-    "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },
   "devDependencies": {
     "@craco/craco": "^7.1.0",
-    "@eslint/js": "^9.17.0",
+    "@eslint/js": "^9.26.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -52,14 +53,24 @@
     "@types/node-7z": "^2.1.10",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.32.1",
+    "@typescript-eslint/parser": "^8.32.1",
     "cross-env": "^7.0.3",
     "electron": "^34.0.2",
     "electron-builder": "^25.1.8",
-    "eslint": "^9.17.0",
+    "eslint": "^9.26.0",
+    "eslint-config-prettier": "^10.1.5",
     "eslint-config-react-app": "^7.0.1",
-    "globals": "^15.14.0",
+    "eslint-import-resolver-typescript": "^4.3.4",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-prettier": "^5.4.0",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^16.1.0",
     "nodemon": "^3.1.9",
+    "prettier": "^3.5.3",
     "tsc-alias": "^1.8.10",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.19.0"
   },
   "build": {
@@ -130,12 +141,6 @@
         }
       ]
     }
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './react/App';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./react/App";
 
-ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-).render(<App />);
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(<App />);

--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -1,24 +1,28 @@
-import { Navigate, Outlet, Route, HashRouter as Router, Routes } from 'react-router-dom';
-import './App.css';
+import { Navigate, Outlet, Route, HashRouter as Router, Routes } from "react-router-dom";
+import "./App.css";
 
-import TabBar from '@components/TabBar';
-import Devices from '@pages/Devices';
-import Games from '@pages/Games';
-import Library from '@pages/Library';
-import Settings from '@pages/Settings';
-import Users from '@pages/Users';
+import TabBar from "@components/TabBar";
+import Devices from "@pages/Devices";
+import Games from "@pages/Games";
+import Library from "@pages/Library";
+import Settings from "@pages/Settings";
+import Users from "@pages/Users";
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-          <TabBar />
-          <div style={{ display: 'flex', overflow: 'auto', flexDirection: 'column' }}>
-            <Outlet />
-          </div>
-        </div>
-        }>
+        <Route
+          path="/"
+          element={
+            <div style={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+              <TabBar />
+              <div style={{ display: "flex", overflow: "auto", flexDirection: "column" }}>
+                <Outlet />
+              </div>
+            </div>
+          }
+        >
           <Route path="/" element={<Navigate to="/games" replace />} />
           <Route path="/games/:id?" element={<Games />} index={true} />
           <Route path="/downloads" element={<Library />} />

--- a/src/react/bridge/ElectronBridge.ts
+++ b/src/react/bridge/ElectronBridge.ts
@@ -2,7 +2,7 @@ import type { BridgeInterface } from ".";
 
 export default class ElectronBridge implements BridgeInterface {
   private global = window as any;
-  
+
   public sendCommand = this.global.sendCommand;
   public registerGameStatusReceiver = this.global.downloads.receive;
 }

--- a/src/react/bridge/WebSocketbridge.ts
+++ b/src/react/bridge/WebSocketbridge.ts
@@ -3,19 +3,22 @@ import { GameStatusInfo } from "./download";
 
 import { CommandEvent } from "@server/comands/types";
 
-type BridgeMessage = {
-  id: string;
-  event: 'command';
-  data: CommandEvent<any, any>;
-} | {
-  id: string;
-  event: 'command-response';
-  error: boolean;
-  data: unknown;
-} | {
-  event: 'download-progress';
-  data: GameStatusInfo;
-}
+type BridgeMessage =
+  | {
+      id: string;
+      event: "command";
+      data: CommandEvent<any, any>;
+    }
+  | {
+      id: string;
+      event: "command-response";
+      error: boolean;
+      data: unknown;
+    }
+  | {
+      event: "download-progress";
+      data: GameStatusInfo;
+    };
 
 class WebSocketBridge implements BridgeInterface {
   private socket: WebSocket;
@@ -23,8 +26,10 @@ class WebSocketBridge implements BridgeInterface {
   private reconnectDelay = 2000;
   private isReconnecting = false;
 
-  private eventHandlers: { [event: string]: {resolve: (data: any) => void, reject: (err: any) => void} } = {};
-  private gameStatusReceiver: ((info: GameStatusInfo) => void) |  null = null;
+  private eventHandlers: {
+    [event: string]: { resolve: (data: any) => void; reject: (err: any) => void };
+  } = {};
+  private gameStatusReceiver: ((info: GameStatusInfo) => void) | null = null;
 
   constructor() {
     this.connectionPromise = Promise.resolve();
@@ -43,14 +48,18 @@ class WebSocketBridge implements BridgeInterface {
   }
 
   private connect(): WebSocket {
-    const port = process.env.NODE_ENV === "development" ? ":3001"
-      : (window.location.port ? ":" + window.location.port : "");
+    const port =
+      process.env.NODE_ENV === "development"
+        ? ":3001"
+        : window.location.port
+          ? ":" + window.location.port
+          : "";
     const socketUrl = "ws://" + window.location.hostname + port;
 
     console.log("Connecting to WebSocket", socketUrl);
     const socket = new WebSocket(socketUrl);
 
-    this.connectionPromise = new Promise((resolve) => {
+    this.connectionPromise = new Promise(resolve => {
       socket.onopen = () => {
         console.log("WebSocket connected");
         this.isReconnecting = false;
@@ -60,20 +69,20 @@ class WebSocketBridge implements BridgeInterface {
 
     socket.onerror = () => {
       this.isReconnecting = false;
-    }
+    };
 
     socket.onclose = () => {
       console.log("WebSocket disconnected");
       this.reconnect();
     };
 
-    socket.onmessage = (message) => {
+    socket.onmessage = message => {
       try {
         const parsedMessage = JSON.parse(message.data) as BridgeMessage;
-        
-        if (parsedMessage.event === 'download-progress' && this.gameStatusReceiver) {
+
+        if (parsedMessage.event === "download-progress" && this.gameStatusReceiver) {
           this.gameStatusReceiver(parsedMessage.data);
-        } else if (parsedMessage.event === 'command-response') {
+        } else if (parsedMessage.event === "command-response") {
           if (this.eventHandlers[parsedMessage.id]) {
             if (parsedMessage.error) {
               this.eventHandlers[parsedMessage.id].reject(parsedMessage.data);
@@ -95,17 +104,21 @@ class WebSocketBridge implements BridgeInterface {
     return socket;
   }
 
-  public async sendCommand<Name extends string, Input, Output>(command: CommandEvent<Input, Name>): Promise<Output> {
+  public async sendCommand<Name extends string, Input, Output>(
+    command: CommandEvent<Input, Name>
+  ): Promise<Output> {
     await this.connectionPromise;
     const uniqueId = Math.random().toString(36);
     return new Promise((resolve, reject) => {
       try {
         this.eventHandlers[uniqueId] = { resolve, reject };
-        this.socket.send(JSON.stringify({ 
-          id: uniqueId,
-          event: 'command',
-          data: command
-        }));
+        this.socket.send(
+          JSON.stringify({
+            id: uniqueId,
+            event: "command",
+            data: command,
+          })
+        );
       } catch (err) {
         reject(err);
       }

--- a/src/react/bridge/devices.ts
+++ b/src/react/bridge/devices.ts
@@ -1,10 +1,10 @@
-import bridge from '.';
+import bridge from ".";
 
-import type { AdbCommandInput, AdbCommandName, AdbCommandOutput } from '@server/comands/types';
-export type { AdbCommandOutput, Device } from '@server/comands/types';
+import type { AdbCommandInput, AdbCommandName, AdbCommandOutput } from "@server/comands/types";
+export type { AdbCommandOutput, Device } from "@server/comands/types";
 
 class DeviceManager {
-  private cache: AdbCommandOutput['list'] = {
+  private cache: AdbCommandOutput["list"] = {
     devices: [],
     users: [],
     apps: [],
@@ -14,7 +14,7 @@ class DeviceManager {
     this.getDevices();
   }
 
-  public getDevicesCache(): AdbCommandOutput['list'] {
+  public getDevicesCache(): AdbCommandOutput["list"] {
     return this.cache;
   }
 
@@ -27,9 +27,9 @@ class DeviceManager {
     return this.cache.apps.some(app => app.packageName === packageName);
   }
 
-  public async getDevices(): Promise<AdbCommandOutput['list']> {
-    const result = bridge.sendCommand<AdbCommandName, AdbCommandInput, AdbCommandOutput['list']>({
-      type: 'adb',
+  public async getDevices(): Promise<AdbCommandOutput["list"]> {
+    const result = bridge.sendCommand<AdbCommandName, AdbCommandInput, AdbCommandOutput["list"]>({
+      type: "adb",
     });
     this.cache = await result;
     return this.cache;
@@ -37,30 +37,30 @@ class DeviceManager {
 
   public async setDevice(serial: string) {
     await bridge.sendCommand<AdbCommandName, AdbCommandInput, void>({
-      type: 'adb',
-      payload: { command: 'selectDevice', serial: serial },
+      type: "adb",
+      payload: { command: "selectDevice", serial: serial },
     });
   }
 
   public async connectWifi(serial: string): Promise<boolean> {
-    return !!await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
-      type: 'adb',
-      payload: { command: 'connectWifi', serial: serial },
-    });
+    return !!(await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
+      type: "adb",
+      payload: { command: "connectWifi", serial: serial },
+    }));
   }
 
   public async connectTcp(address: string): Promise<boolean> {
-    return !!await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
-      type: 'adb',
-      payload: { command: 'connectTcp', address },
-    });
+    return !!(await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
+      type: "adb",
+      payload: { command: "connectTcp", address },
+    }));
   }
 
   public async pair(address: string, code: string): Promise<boolean> {
-    return !!await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
-      type: 'adb',
-      payload: { command: 'pair', address, code },
-    });
+    return !!(await bridge.sendCommand<AdbCommandName, AdbCommandInput, string | null>({
+      type: "adb",
+      payload: { command: "pair", address, code },
+    }));
   }
 }
 

--- a/src/react/bridge/download.ts
+++ b/src/react/bridge/download.ts
@@ -1,7 +1,7 @@
-import bridge from '.';
+import bridge from ".";
 
-import type { GamesCommandName, GamesCommandPayload, GameStatusInfo } from '@server/comands/types';
-export type { GameStatusInfo, GameStatusType } from '@server/comands/types';
+import type { GamesCommandName, GamesCommandPayload, GameStatusInfo } from "@server/comands/types";
+export type { GameStatusInfo, GameStatusType } from "@server/comands/types";
 
 type ListenerCallback = (info: GameStatusInfo) => void;
 type DownloadingListener = (info: GameStatusInfo[]) => void;
@@ -24,7 +24,7 @@ class GameDownloadManager {
       this.listeners[id] = [];
     }
     this.listeners[id].push(callback);
-    callback(this.getGameStatusInfo(id) || { id, status: 'none' });
+    callback(this.getGameStatusInfo(id) || { id, status: "none" });
 
     return () => {
       this.removeListener(id, callback);
@@ -51,11 +51,13 @@ class GameDownloadManager {
   }
 
   public removeDownloadingListener(callback: DownloadingListener) {
-    this.downloadingGamesChangeListeners = this.downloadingGamesChangeListeners.filter(listener => listener !== callback);
+    this.downloadingGamesChangeListeners = this.downloadingGamesChangeListeners.filter(
+      listener => listener !== callback
+    );
   }
 
   public emitDownloading() {
-    this.downloadingGamesChangeListeners.forEach(callback => 
+    this.downloadingGamesChangeListeners.forEach(callback =>
       callback(Object.values(this.downloadingGames))
     );
   }
@@ -66,10 +68,10 @@ class GameDownloadManager {
 
   private async emit(id: string, info: GameStatusInfo) {
     this.downloadingGames[id] = info;
-    if(!this.getGameStatusInfo(id)) {
+    if (!this.getGameStatusInfo(id)) {
       this.emitDownloading();
     }
-    if(!this.getGameStatusInfo(id) || info.status !== 'downloading') {
+    if (!this.getGameStatusInfo(id) || info.status !== "downloading") {
       this.emitDownloading();
     }
 
@@ -78,29 +80,31 @@ class GameDownloadManager {
   }
 
   public async getDownloadedGames(): Promise<string[]> {
-    const downloadedIds = await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string[]>({
-      type: 'games',
-      payload: { action: 'listDownloaded' },
-    })
+    const downloadedIds = await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string[]>(
+      {
+        type: "games",
+        payload: { action: "listDownloaded" },
+      }
+    );
     this.downloadedCache = downloadedIds;
     return downloadedIds;
   }
 
   public isGameDownloaded(id: string): boolean {
-    return this.downloadedCache.includes(id) || this.downloadingGames[id]?.status === 'downloaded';
+    return this.downloadedCache.includes(id) || this.downloadingGames[id]?.status === "downloaded";
   }
 
   public downloadGame(id: string) {
     bridge.sendCommand<GamesCommandName, GamesCommandPayload>({
-      type: 'games',
-      payload: { action: 'download', id},
+      type: "games",
+      payload: { action: "download", id },
     });
   }
 
   public async remove(id: string): Promise<void> {
     await bridge.sendCommand<GamesCommandName, GamesCommandPayload>({
-      type: 'games',
-      payload: { action: 'removeDownload', id},
+      type: "games",
+      payload: { action: "removeDownload", id },
     });
     this.downloadedCache = this.downloadedCache.filter(gameId => gameId !== id);
     delete this.downloadingGames[id];
@@ -109,18 +113,17 @@ class GameDownloadManager {
 
   public cancel(id: string) {
     bridge.sendCommand<GamesCommandName, GamesCommandPayload>({
-      type: 'games',
-      payload: { action: 'cancel', id },
+      type: "games",
+      payload: { action: "cancel", id },
     });
   }
 
   public async getLocalFiles(id: string) {
     return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string[]>({
-      type: 'games',
-      payload: { action: 'getLocalFiles', id },
+      type: "games",
+      payload: { action: "getLocalFiles", id },
     });
   }
-
 }
 
 const gameDownloadManager = new GameDownloadManager();

--- a/src/react/bridge/games.ts
+++ b/src/react/bridge/games.ts
@@ -1,18 +1,18 @@
-import bridge from '.';
+import bridge from ".";
 
-import type { Game, GamesCommandName, GamesCommandPayload } from '@server/comands/types';
-export type { Game } from '@server/comands/types';
+import type { Game, GamesCommandName, GamesCommandPayload } from "@server/comands/types";
+export type { Game } from "@server/comands/types";
 
-const cacheKey = 'games';
+const cacheKey = "games";
 
 class GamesManager {
   private cache: Game[];
 
   constructor() {
     try {
-      this.cache = JSON.parse(localStorage.getItem(cacheKey) || '[]');
+      this.cache = JSON.parse(localStorage.getItem(cacheKey) || "[]");
     } catch (e) {
-      console.error('Failed to load games cache', e);
+      console.error("Failed to load games cache", e);
       this.cache = [];
     }
   }
@@ -22,40 +22,40 @@ class GamesManager {
   }
 
   public getGameFromCache(packageName: string): Game | null {
-    return this.cache.find((game) => game.packageName === packageName) || null;
+    return this.cache.find(game => game.packageName === packageName) || null;
   }
 
   public getGameFromCacheById(id: string): Game | null {
-    return this.cache.find((game) => game.id === id) || null;
+    return this.cache.find(game => game.id === id) || null;
   }
 
   public async getGames(): Promise<Game[]> {
     this.cache = await bridge.sendCommand<GamesCommandName, GamesCommandPayload, Game[]>({
-      type: 'games',
-      payload: { action: 'list' }
+      type: "games",
+      payload: { action: "list" },
     });
     localStorage.setItem(cacheKey, JSON.stringify(this.cache));
     return this.cache;
   }
 
-  public async install(id: string, justMissing: boolean = false): Promise<string|null> {
-    return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string|null>({
-      type: 'games',
-      payload: { action: 'install', justMissing, id },
+  public async install(id: string, justMissing: boolean = false): Promise<string | null> {
+    return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string | null>({
+      type: "games",
+      payload: { action: "install", justMissing, id },
     });
   }
 
   public async uninstall(id: string) {
-    return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string|null>({
-      type: 'games',
-      payload: { action: 'uninstall', id },
+    return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string | null>({
+      type: "games",
+      payload: { action: "uninstall", id },
     });
   }
 
   public async getObbFileList(id: string): Promise<string[]> {
     return await bridge.sendCommand<GamesCommandName, GamesCommandPayload, string[]>({
-      type: 'games',
-      payload: { action: 'listObbFiles', id },
+      type: "games",
+      payload: { action: "listObbFiles", id },
     });
   }
 }

--- a/src/react/bridge/image.ts
+++ b/src/react/bridge/image.ts
@@ -1,13 +1,15 @@
 import { isElectron } from ".";
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = process.env.NODE_ENV === "development";
 
 const getImagePath = (packageName?: string): string => {
   if (!packageName) return "";
-  return (isElectron
-    ? 'game-image://'
-    : (isDevelopment ? `${window.location.protocol}//${window.location.hostname}:3001` : '') + '/game-image/')
-    + packageName;
-}
+  return (
+    (isElectron
+      ? "game-image://"
+      : (isDevelopment ? `${window.location.protocol}//${window.location.hostname}:3001` : "") +
+        "/game-image/") + packageName
+  );
+};
 
 export default getImagePath;

--- a/src/react/bridge/index.ts
+++ b/src/react/bridge/index.ts
@@ -1,7 +1,7 @@
-import type { CommandSender, GameStatusInfo } from '@server/comands/types';
+import type { CommandSender, GameStatusInfo } from "@server/comands/types";
 
-import ElectronBridge from './ElectronBridge';
-import WebSocketBridge from './WebSocketbridge';
+import ElectronBridge from "./ElectronBridge";
+import WebSocketBridge from "./WebSocketbridge";
 
 export interface BridgeInterface {
   sendCommand: CommandSender;

--- a/src/react/bridge/settings/index.ts
+++ b/src/react/bridge/settings/index.ts
@@ -1,43 +1,58 @@
 import semver from "semver";
 
-import { promisse, RepoDownloadsInfo, repoDownloadsInfo } from './repoInfo';
+import { promisse, RepoDownloadsInfo, repoDownloadsInfo } from "./repoInfo";
 
-import bridge from '@bridge';
-import { DevToolsCommandName, Settings, SettingsCommandName, SettingsCommandOutputs, SettingsCommandPayload, SystemHelth } from '@server/comands/types';
-export type { GitHubRelease, Settings, SystemHelth } from '@server/comands/types';
+import bridge from "@bridge";
+import {
+  DevToolsCommandName,
+  Settings,
+  SettingsCommandName,
+  SettingsCommandOutputs,
+  SettingsCommandPayload,
+  SystemHelth,
+} from "@server/comands/types";
+export type { GitHubRelease, Settings, SystemHelth } from "@server/comands/types";
 export type { RepoDownloadsInfo };
 
 class SettingsManager {
   public async getHelthInfo(): Promise<SystemHelth> {
-    return bridge.sendCommand<SettingsCommandName, SettingsCommandPayload, SettingsCommandOutputs['systemHelth']>({
-      type: 'settings',
+    return bridge.sendCommand<
+      SettingsCommandName,
+      SettingsCommandPayload,
+      SettingsCommandOutputs["systemHelth"]
+    >({
+      type: "settings",
       payload: {
-        action: 'getSystemHelth'
-      }
+        action: "getSystemHelth",
+      },
     });
   }
 
   public openDevTools() {
     bridge.sendCommand<DevToolsCommandName>({
-      type: 'devTools',
+      type: "devTools",
     });
   }
 
   public async getSettings(): Promise<Settings> {
-    return await bridge.sendCommand<SettingsCommandName, SettingsCommandPayload, SettingsCommandOutputs['settings']>({
-      type: 'settings',
+    return await bridge.sendCommand<
+      SettingsCommandName,
+      SettingsCommandPayload,
+      SettingsCommandOutputs["settings"]
+    >({
+      type: "settings",
       payload: {
-        action: 'list',
-      }
+        action: "list",
+      },
     });
   }
 
   public async setDownloadPath(): Promise<Settings> {
     return await bridge.sendCommand<SettingsCommandName, SettingsCommandPayload>({
-      type: 'settings',
+      type: "settings",
       payload: {
-        action: 'setDownloadsDir',
-      }
+        action: "setDownloadsDir",
+      },
     });
   }
 
@@ -50,10 +65,10 @@ class SettingsManager {
     return repoDownloadsInfo;
   }
 
-  public async hasUpdate(): Promise<string|null> {
-    const info = (await this.fetchReposInfo())['victorwads/QRookieNode'];
+  public async hasUpdate(): Promise<string | null> {
+    const info = (await this.fetchReposInfo())["victorwads/QRookieNode"];
     const appVersion = (await this.getHelthInfo()).appVersion;
-    
+
     if (semver.gt(info.lastAppVersion, appVersion)) {
       return `https://github.com/victorwads/QRookieNode/releases/tag/${info.lastAppVersion}`;
     }

--- a/src/react/bridge/settings/repoInfo.ts
+++ b/src/react/bridge/settings/repoInfo.ts
@@ -1,7 +1,7 @@
-import type { GitHubRelease } from '@server/comands/types';
+import type { GitHubRelease } from "@server/comands/types";
 
 // https://api.github.com/rate_limit
-const storageKey = 'repoDownloadsInfoV2';
+const storageKey = "repoDownloadsInfoV2";
 const storageValidTime = 1000 * 60 * 60 * 2; // 2 hours
 const repos = {
   // "glaumar/QRookie": "Qml Rookie by Glaumar",
@@ -10,71 +10,77 @@ const repos = {
 };
 
 type Downloads = {
-  name: string,
-  repo: string,
-  byExt: { [ext: string]: number },
-  total: number,
-  lastAppVersion: string,
-  lastUpdate: number
+  name: string;
+  repo: string;
+  byExt: { [ext: string]: number };
+  total: number;
+  lastAppVersion: string;
+  lastUpdate: number;
 };
 
 export type RepoDownloadsInfo = {
   [repoName in keyof typeof repos]: Downloads;
 };
 
-export const repoDownloadsInfo: RepoDownloadsInfo = JSON.parse(localStorage.getItem(storageKey) || '{}');
-export const promisse = Promise.all(Object.entries(repos).map(([name, alias]) => {
-  const repoName = name as keyof typeof repos;
-  const cache = repoDownloadsInfo[repoName];
-  if (cache) {
-    const cacheUntil = cache.lastUpdate + storageValidTime;
-    if (cacheUntil > Date.now()) {
-      console.log('Cache will be used for more', (cacheUntil - Date.now()) / 1000, 'seconds');
-      return Promise.resolve();
+export const repoDownloadsInfo: RepoDownloadsInfo = JSON.parse(
+  localStorage.getItem(storageKey) || "{}"
+);
+export const promisse = Promise.all(
+  Object.entries(repos).map(([name, alias]) => {
+    const repoName = name as keyof typeof repos;
+    const cache = repoDownloadsInfo[repoName];
+    if (cache) {
+      const cacheUntil = cache.lastUpdate + storageValidTime;
+      if (cacheUntil > Date.now()) {
+        console.log("Cache will be used for more", (cacheUntil - Date.now()) / 1000, "seconds");
+        return Promise.resolve();
+      }
     }
-  }
-  console.log('Fetching', repoName);
+    console.log("Fetching", repoName);
 
-  return fetch(`https://api.github.com/repos/${repoName}/releases`).then(response => {
-    if (response.ok) {
-      return response.json();
-    } else {
-      throw new Error('Failed to fetch repository information');
-    }
-  }).then((releases: GitHubRelease[]) => {
-    let lastAppVersion = '';
-    if(releases.length > 0) {
-      lastAppVersion = releases[0].tag_name
-    }
-
-    const downloads: Downloads = {
-      name: alias,
-      repo: repoName,
-      byExt: {},
-      total: 0,
-      lastAppVersion,
-      lastUpdate: Date.now(),
-    };
-    releases.forEach(release => {
-      release.assets.forEach(asset => {
-        downloads.total += asset.download_count;
-        let ext = asset.name.split('.').pop() || 'unknown';
-        if(asset.name.includes('.exe')) {
-          ext = 'Windows.'+ext; 
-        } else if(asset.name.includes('Linux')) {
-          ext = 'Linux.'+ext; 
-        } else if(asset.name.includes('Mac')) {
-          ext = 'Mac.'+ext; 
-        } else if(asset.name.includes('Headless')) {
-          ext = 'Android/Headless.'+ext; 
+    return fetch(`https://api.github.com/repos/${repoName}/releases`)
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error("Failed to fetch repository information");
         }
-        downloads.byExt[ext] = (downloads.byExt[ext] || 0) + asset.download_count;
       })
-    });
-    repoDownloadsInfo[repoName] = downloads;
+      .then((releases: GitHubRelease[]) => {
+        let lastAppVersion = "";
+        if (releases.length > 0) {
+          lastAppVersion = releases[0].tag_name;
+        }
+
+        const downloads: Downloads = {
+          name: alias,
+          repo: repoName,
+          byExt: {},
+          total: 0,
+          lastAppVersion,
+          lastUpdate: Date.now(),
+        };
+        releases.forEach(release => {
+          release.assets.forEach(asset => {
+            downloads.total += asset.download_count;
+            let ext = asset.name.split(".").pop() || "unknown";
+            if (asset.name.includes(".exe")) {
+              ext = "Windows." + ext;
+            } else if (asset.name.includes("Linux")) {
+              ext = "Linux." + ext;
+            } else if (asset.name.includes("Mac")) {
+              ext = "Mac." + ext;
+            } else if (asset.name.includes("Headless")) {
+              ext = "Android/Headless." + ext;
+            }
+            downloads.byExt[ext] = (downloads.byExt[ext] || 0) + asset.download_count;
+          });
+        });
+        repoDownloadsInfo[repoName] = downloads;
+      });
   })
-}));
+);
 
 promisse.then(() => {
   localStorage.setItem(storageKey, JSON.stringify(repoDownloadsInfo));
-})
+});

--- a/src/react/components/BooleanView.tsx
+++ b/src/react/components/BooleanView.tsx
@@ -6,9 +6,9 @@ interface BooleanViewProps {
 
 const BooleanView: React.FC<BooleanViewProps> = ({ value }: BooleanViewProps) => {
   return (
-    <Icon 
-      icon={value ? Icons.solid.faCheckCircle : Icons.solid.faTimesCircle} 
-      style={{ color: value ? "green" : "red" }} 
+    <Icon
+      icon={value ? Icons.solid.faCheckCircle : Icons.solid.faTimesCircle}
+      style={{ color: value ? "green" : "red" }}
     />
   );
 };

--- a/src/react/components/Button.tsx
+++ b/src/react/components/Button.tsx
@@ -1,6 +1,5 @@
-
-import './Button.css';
-import Icon, { IconDefinition } from './Icons';
+import "./Button.css";
+import Icon, { IconDefinition } from "./Icons";
 
 export interface ButtonProps {
   icon: IconDefinition;
@@ -10,10 +9,12 @@ export interface ButtonProps {
 }
 
 const Button: React.FC<ButtonProps> = ({ icon, onClick, children, wide }: ButtonProps) => {
-  return <button className={`simple-buttom${wide? ' wide': ''}`} onClick={onClick}>
-    <Icon icon={icon} />
-    {children}
-  </button>;
+  return (
+    <button className={`simple-buttom${wide ? " wide" : ""}`} onClick={onClick}>
+      <Icon icon={icon} />
+      {children}
+    </button>
+  );
 };
 
 export default Button;

--- a/src/react/components/DeviceInfoCard.tsx
+++ b/src/react/components/DeviceInfoCard.tsx
@@ -18,22 +18,41 @@ const DeviceInfoCard: React.FC<{ deviceInfo: Device }> = ({ deviceInfo }) => {
     <div className="device-info">
       <h2>Selected Device Info</h2>
       <ul>
-        <li><strong>Serial:</strong> {deviceInfo.serial}</li>
-        <li><strong>Model:</strong> {deviceInfo.model}</li>
-        <li><strong>IP:</strong> {deviceInfo.ip}</li>
-        <li><strong>Android Version:</strong> {deviceInfo.androidVersion}</li>
-        <li><strong>SDK Version:</strong> {deviceInfo.sdkVersion}</li>
         <li>
-          <strong>Storage:</strong>  {formatSize(total)}
-          <div><ProgressBar value={used} max={total} isReversed /></div>
+          <strong>Serial:</strong> {deviceInfo.serial}
+        </li>
+        <li>
+          <strong>Model:</strong> {deviceInfo.model}
+        </li>
+        <li>
+          <strong>IP:</strong> {deviceInfo.ip}
+        </li>
+        <li>
+          <strong>Android Version:</strong> {deviceInfo.androidVersion}
+        </li>
+        <li>
+          <strong>SDK Version:</strong> {deviceInfo.sdkVersion}
+        </li>
+        <li>
+          <strong>Storage:</strong> {formatSize(total)}
+          <div>
+            <ProgressBar value={used} max={total} isReversed />
+          </div>
           <ul>
-            <li><strong>Used:</strong> {formatSize(used)}  -- {((used / total) * 100).toFixed(2)}%</li>
-            <li><strong>Free:</strong> {formatSize(total - used)} -- {((total - used) / total * 100).toFixed(2)}%</li>
+            <li>
+              <strong>Used:</strong> {formatSize(used)} -- {((used / total) * 100).toFixed(2)}%
+            </li>
+            <li>
+              <strong>Free:</strong> {formatSize(total - used)} --{" "}
+              {(((total - used) / total) * 100).toFixed(2)}%
+            </li>
           </ul>
         </li>
         <li>
           <strong>Battery Level:</strong> {deviceInfo.batteryLevel}%
-          <div><ProgressBar value={deviceInfo.batteryLevel || 0} max={100} /></div>
+          <div>
+            <ProgressBar value={deviceInfo.batteryLevel || 0} max={100} />
+          </div>
         </li>
       </ul>
     </div>

--- a/src/react/components/DeviceList.tsx
+++ b/src/react/components/DeviceList.tsx
@@ -15,12 +15,18 @@ const DevicesList: React.FC<DeviceListProps> = ({ devices, onConnect, onConnectW
     <div className="devices-list">
       <h2>Devices</h2>
       <ul>
-        {devices.map((device) => (
+        {devices.map(device => (
           <li key={device.serial}>
-            <strong>Serial:</strong> {device.serial} - <strong>Model:</strong> {device.model || "Unknown"}
-            <Button onClick={() =>onConnect(device.serial)} icon={Icons.solid.faLink}>Connect</Button>
-            {device.ip && !device.serial.includes(device.ip) &&
-              <Button onClick={() =>onConnectWifi(device.serial)} icon={Icons.solid.faWifi}>Network Connect</Button>}
+            <strong>Serial:</strong> {device.serial} - <strong>Model:</strong>{" "}
+            {device.model || "Unknown"}
+            <Button onClick={() => onConnect(device.serial)} icon={Icons.solid.faLink}>
+              Connect
+            </Button>
+            {device.ip && !device.serial.includes(device.ip) && (
+              <Button onClick={() => onConnectWifi(device.serial)} icon={Icons.solid.faWifi}>
+                Network Connect
+              </Button>
+            )}
           </li>
         ))}
       </ul>

--- a/src/react/components/GameCard.tsx
+++ b/src/react/components/GameCard.tsx
@@ -27,56 +27,74 @@ export interface GameCardProps {
   onSelect?: (game: Game) => void;
 }
 
-const GameCard: React.FC<GameCardProps> = ({ game, onSelect, onDownload, verbose, downloaded }: GameCardProps) => {
-  const [gameStatus, setGameStatus] = useState<GameStatusInfo|null>(downloadManager.getGameStatusInfo(game.id));
+const GameCard: React.FC<GameCardProps> = ({
+  game,
+  onSelect,
+  onDownload,
+  verbose,
+  downloaded,
+}: GameCardProps) => {
+  const [gameStatus, setGameStatus] = useState<GameStatusInfo | null>(
+    downloadManager.getGameStatusInfo(game.id)
+  );
   const [comparation, setComparation] = useState<GameFileComparison[]>([]);
-  const [deviceVersion, setDeviceVersion] = useState<number|null>(null);
-  
+  const [deviceVersion, setDeviceVersion] = useState<number | null>(null);
+
   const install = async (justMissing: boolean = false) => {
-    if (gameStatus?.status === 'installing' || gameStatus?.status === 'unzipping' || gameStatus?.status === 'pushing app data') return;
-    
+    if (
+      gameStatus?.status === "installing" ||
+      gameStatus?.status === "unzipping" ||
+      gameStatus?.status === "pushing app data"
+    )
+      return;
+
     const result = await gameManager.install(game.id, justMissing === true);
     if (result) {
       alert(result);
     } else {
-      alert('Game installed successfully');
+      alert("Game installed successfully");
     }
     loadComparation();
   };
 
   const remove = async () => {
-    if(!window.confirm('Are you sure you want to remove this game?')) return;
+    if (!window.confirm("Are you sure you want to remove this game?")) return;
     await downloadManager.remove(game.id);
     setGameStatus(null);
-  }
+  };
 
   const cancel = async () => {
-    if(!window.confirm('Are you sure you want to cancel this download?')) return;
+    if (!window.confirm("Are you sure you want to cancel this download?")) return;
     downloadManager.cancel(game.id);
-  }
+  };
 
   const uninstall = async () => {
-    if(!window.confirm('Are you sure you want to uninstall this game? You will lose all your progress.')) return;
+    if (
+      !window.confirm(
+        "Are you sure you want to uninstall this game? You will lose all your progress."
+      )
+    )
+      return;
     await gameManager.uninstall(game.id);
     loadComparation();
     setDeviceVersion(null);
     setGameStatus(null);
-  }
+  };
 
   const loadComparation = async () => {
-    if(verbose && game.packageName) {
+    if (verbose && game.packageName) {
       compareFiles(game.id).then(setComparation);
       setDeviceVersion(deviceManager.getPackageVersion(game.packageName));
     }
-  }
+  };
 
   useEffect(() => {
     loadComparation();
 
     let lastFile = "";
-    return downloadManager.addListener(game.id, (info) => {
-      setGameStatus(info ? {...info} : null);
-      if (info?.status === 'pushing app data' && comparation.length > 0) {
+    return downloadManager.addListener(game.id, info => {
+      setGameStatus(info ? { ...info } : null);
+      if (info?.status === "pushing app data" && comparation.length > 0) {
         comparation.forEach(file => {
           if (file.fileName === lastFile) {
             file.deviceExists = true;
@@ -85,112 +103,203 @@ const GameCard: React.FC<GameCardProps> = ({ game, onSelect, onDownload, verbose
         lastFile = info.file.name;
         setComparation([...comparation]);
       }
-      if (info?.status === 'installed') {
+      if (info?.status === "installed") {
         loadComparation();
       }
-
     });
   }, [game, verbose]);
 
   let isDownloaded = downloadManager.isGameDownloaded(game.id);
   let isInstalled = deviceManager.isGameInstalled(game.packageName);
   const status: React.ReactNode[] = [];
-  if(gameStatus?.status === 'installing') {
-    status.push(<div key={status.length} className="game-card-task">Installing</div>)
-  } else if (gameStatus?.status === 'downloading') {
-    status.push(<div key={status.length} className="game-card-download-progress">
-      {gameStatus.files.map((file, index) => {
-        const totalPercentage = file.bytesReceived / gameStatus.bytesTotal * 100;
-        return <div key={index} style={{width: totalPercentage+'%'}}></div>
-      })}
-    </div>)
-    status.push(<Button key={status.length} onClick={cancel} icon={Icons.solid.faTrash}>Cancel</Button>)
-  } else if (gameStatus?.status === 'unzipping') {
-    status.push(<div key={status.length} className="game-card-task">Unzipping</div>)
-  } else if (gameStatus?.status === 'pushing app data') {
-    status.push(<div key={status.length} className="game-card-task">Pushing App data</div>)
-  } else if (gameStatus?.status === 'cancelling') {
-    status.push(<div key={status.length} className="game-card-task">Cancelling Download</div>)
+  if (gameStatus?.status === "installing") {
+    status.push(
+      <div key={status.length} className="game-card-task">
+        Installing
+      </div>
+    );
+  } else if (gameStatus?.status === "downloading") {
+    status.push(
+      <div key={status.length} className="game-card-download-progress">
+        {gameStatus.files.map((file, index) => {
+          const totalPercentage = (file.bytesReceived / gameStatus.bytesTotal) * 100;
+          return <div key={index} style={{ width: totalPercentage + "%" }}></div>;
+        })}
+      </div>
+    );
+    status.push(
+      <Button key={status.length} onClick={cancel} icon={Icons.solid.faTrash}>
+        Cancel
+      </Button>
+    );
+  } else if (gameStatus?.status === "unzipping") {
+    status.push(
+      <div key={status.length} className="game-card-task">
+        Unzipping
+      </div>
+    );
+  } else if (gameStatus?.status === "pushing app data") {
+    status.push(
+      <div key={status.length} className="game-card-task">
+        Pushing App data
+      </div>
+    );
+  } else if (gameStatus?.status === "cancelling") {
+    status.push(
+      <div key={status.length} className="game-card-task">
+        Cancelling Download
+      </div>
+    );
   } else {
-    isInstalled = isInstalled || gameStatus?.status === 'installed';
+    isInstalled = isInstalled || gameStatus?.status === "installed";
     if (isInstalled) {
-      status.push(<Button key={status.length} wide onClick={uninstall} icon={Icons.solid.faMinusCircle}>Uninstall</Button>)
+      status.push(
+        <Button key={status.length} wide onClick={uninstall} icon={Icons.solid.faMinusCircle}>
+          Uninstall
+        </Button>
+      );
     }
     isDownloaded = isDownloaded || downloaded || false;
     if (isDownloaded) {
       if (isInstalled) {
-        if(comparation.length > 0 && comparation.some(file => !file.deviceExists)) {
-          status.push(<Button key={status.length} onClick={() => install(true)} icon={Icons.solid.faDownload}>Install Missing Files</Button>)
+        if (comparation.length > 0 && comparation.some(file => !file.deviceExists)) {
+          status.push(
+            <Button key={status.length} onClick={() => install(true)} icon={Icons.solid.faDownload}>
+              Install Missing Files
+            </Button>
+          );
         } else {
-          status.push(<Button key={status.length} wide onClick={install} icon={Icons.solid.faBoxOpen}>Reinstall</Button>)    
+          status.push(
+            <Button key={status.length} wide onClick={install} icon={Icons.solid.faBoxOpen}>
+              Reinstall
+            </Button>
+          );
         }
       } else {
-        status.push(<Button key={status.length} wide onClick={install} icon={Icons.solid.faDownload}>Install</Button>)
+        status.push(
+          <Button key={status.length} wide onClick={install} icon={Icons.solid.faDownload}>
+            Install
+          </Button>
+        );
       }
-      status.push(<Button key={status.length} onClick={remove} icon={Icons.solid.faTrash}>Remove</Button>)
+      status.push(
+        <Button key={status.length} onClick={remove} icon={Icons.solid.faTrash}>
+          Remove
+        </Button>
+      );
     } else if (onDownload) {
-      status.push(<Button key={status.length} wide onClick={() => onDownload(game)} icon={Icons.solid.faDownload}>Download</Button>)
+      status.push(
+        <Button
+          key={status.length}
+          wide
+          onClick={() => onDownload(game)}
+          icon={Icons.solid.faDownload}
+        >
+          Download
+        </Button>
+      );
     }
   }
 
-  return <>
-    <div className={"game-card" + (verbose ? ' verbose' : '')}>
-      <div className="game-card-image" onClick={() => onSelect && onSelect(game)} style={{backgroundImage: `url(${getImagePath(game.packageName)})`}}>
-        {/* Add Eye Icon */}
-      </div>
-      <div className="game-card-content">
-        <h3 className="game-card-title" onClick={() => onSelect && onSelect(game)}>{game.normalName}</h3>
-        {game.name !== game.normalName && <p className="game-card-subtitle">{game.name}</p>}
-        {verbose && <div style={{ display: 'flex', flexDirection: 'row',  flex: 1, textAlign: 'left', margin: '15px' }}>
-          <div style={{ marginRight: 10 }}>
-            <div><strong>ID:</strong></div>
-            <div><strong>Version:</strong></div>
-            {deviceVersion && deviceVersion != game.version && <div><strong>Device Version:</strong></div>}
-            <div><strong>Category:</strong></div>
-            <div><strong>Package Name:</strong></div>
-            <div><strong>Last Updated:</strong></div>
-          </div>
-          <div style={{ flex: 1 }}>
-            <div>{game.id}</div>
-            <div>{game.version}</div>
-            {deviceVersion && deviceVersion != game.version && <div>{deviceVersion}</div>}
-            <div>{game.category}</div>
-            <div>{game.packageName}</div>
-            <div>{game.lastUpdated}</div>
-          </div>
-        </div>}
-        <p className="game-card-size">{formatSize(game.size)}</p>
-        <div  style={{display: 'flex', gap: 5, padding: 10, alignItems: 'center'}}>
-          {status}
+  return (
+    <>
+      <div className={"game-card" + (verbose ? " verbose" : "")}>
+        <div
+          className="game-card-image"
+          onClick={() => onSelect && onSelect(game)}
+          style={{ backgroundImage: `url(${getImagePath(game.packageName)})` }}
+        >
+          {/* Add Eye Icon */}
+        </div>
+        <div className="game-card-content">
+          <h3 className="game-card-title" onClick={() => onSelect && onSelect(game)}>
+            {game.normalName}
+          </h3>
+          {game.name !== game.normalName && <p className="game-card-subtitle">{game.name}</p>}
+          {verbose && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flex: 1,
+                textAlign: "left",
+                margin: "15px",
+              }}
+            >
+              <div style={{ marginRight: 10 }}>
+                <div>
+                  <strong>ID:</strong>
+                </div>
+                <div>
+                  <strong>Version:</strong>
+                </div>
+                {deviceVersion && deviceVersion != game.version && (
+                  <div>
+                    <strong>Device Version:</strong>
+                  </div>
+                )}
+                <div>
+                  <strong>Category:</strong>
+                </div>
+                <div>
+                  <strong>Package Name:</strong>
+                </div>
+                <div>
+                  <strong>Last Updated:</strong>
+                </div>
+              </div>
+              <div style={{ flex: 1 }}>
+                <div>{game.id}</div>
+                <div>{game.version}</div>
+                {deviceVersion && deviceVersion != game.version && <div>{deviceVersion}</div>}
+                <div>{game.category}</div>
+                <div>{game.packageName}</div>
+                <div>{game.lastUpdated}</div>
+              </div>
+            </div>
+          )}
+          <p className="game-card-size">{formatSize(game.size)}</p>
+          <div style={{ display: "flex", gap: 5, padding: 10, alignItems: "center" }}>{status}</div>
         </div>
       </div>
-    </div>
-    {verbose && gameStatus && <GameVerboseInfo gameStatus={gameStatus} />}
-    { isDownloaded && comparation.length > 0 && <div style={{flex: 1}}>
-      <table border={1} style={{width: '100%'}}>
-        <thead>
-          <tr>
-            <th>File Name</th>
-            <th>On Local</th>
-            <th>On Device</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><b>APK Version</b></td>
-            <td align="center">{game.version}</td>
-            <td align="center">{deviceVersion || "Not Found"}</td>
-          </tr>
-          {comparation
-            .sort((a, b) => a.deviceExists === b.deviceExists ? 0 : a.deviceExists ? 1 : -1)
-            .map((file, index) => <tr key={index}>
-              <td>{file.fileName}</td>
-              <td align="center"><BooleanView value={file.localExists} /></td>
-              <td align="center"><BooleanView value={file.deviceExists} /></td>
-            </tr>)}
-        </tbody>
-      </table></div>}
-  </>;
+      {verbose && gameStatus && <GameVerboseInfo gameStatus={gameStatus} />}
+      {isDownloaded && comparation.length > 0 && (
+        <div style={{ flex: 1 }}>
+          <table border={1} style={{ width: "100%" }}>
+            <thead>
+              <tr>
+                <th>File Name</th>
+                <th>On Local</th>
+                <th>On Device</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <b>APK Version</b>
+                </td>
+                <td align="center">{game.version}</td>
+                <td align="center">{deviceVersion || "Not Found"}</td>
+              </tr>
+              {comparation
+                .sort((a, b) => (a.deviceExists === b.deviceExists ? 0 : a.deviceExists ? 1 : -1))
+                .map((file, index) => (
+                  <tr key={index}>
+                    <td>{file.fileName}</td>
+                    <td align="center">
+                      <BooleanView value={file.localExists} />
+                    </td>
+                    <td align="center">
+                      <BooleanView value={file.deviceExists} />
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
 };
 
 const compareFiles = async (id: string): Promise<GameFileComparison[]> => {
@@ -200,7 +309,7 @@ const compareFiles = async (id: string): Promise<GameFileComparison[]> => {
   ]);
   const allFiles = [
     ...localFiles.filter(file => file.trim() !== ""),
-    ...deviceFiles.filter(file => file.trim() !== "")
+    ...deviceFiles.filter(file => file.trim() !== ""),
   ];
 
   return Array.from(allFiles).map(file => ({

--- a/src/react/components/GameVerboseInfo.tsx
+++ b/src/react/components/GameVerboseInfo.tsx
@@ -1,4 +1,3 @@
-
 import { GameStatusInfo } from "@react/bridge/download";
 
 export function formatSize(size: number = 0): string {
@@ -12,39 +11,84 @@ export interface GameVerboseInfoProps {
   gameStatus: GameStatusInfo;
 }
 
-const validStatus = ['downloading', 'installing', 'pushing app data'];
+const validStatus = ["downloading", "installing", "pushing app data"];
 
 const GameVerboseInfo: React.FC<GameVerboseInfoProps> = ({ gameStatus }: GameVerboseInfoProps) => {
   if (!validStatus.includes(gameStatus.status)) return null;
-  return <div style={{flex: 1}}>
-    {gameStatus.status === 'downloading' && <div className="game-card-download-info">
-      <strong>Downloading</strong>
-      <div><strong>Download URL: </strong>{gameStatus.url}</div>
-      <div><strong>Bytes Received: </strong>{gameStatus.bytesReceived}</div>
-      <div><strong>Bytes Total: </strong>{gameStatus.bytesTotal}</div>
-      <div><strong>Speed: </strong>{gameStatus.speed}</div>
-      <div><strong>Percent: </strong>{gameStatus.percent.toFixed(2)}%</div>
-      <ul>
-        {gameStatus.files
-          .filter(info => info.percent !== 100 && info.percent !== 0)
-          .map((file, index) => <li key={index}>
-            <div><strong>File: </strong>{file.url}</div>
-            <div><strong>Bytes Received: </strong>{file.bytesReceived}</div>
-            <div><strong>Bytes Total: </strong>{file.bytesTotal}</div>
-            <div><strong>Percent: </strong>{file.percent.toFixed(2)}%</div>
-          </li>)}
-      </ul>
-    </div>}
-    {gameStatus.status === 'installing' && <div className="game-card-download-info">
-      <strong>Installing</strong>
-      <div><strong>Filename:</strong> {gameStatus.installingFile}</div>
-    </div>}
-    {gameStatus.status === 'pushing app data' && <div className="game-card-download-info">
-      <strong>Pusing App Data</strong>
-      <div><strong>Files:</strong>{gameStatus.file.index + 1}/{gameStatus.totalFiles}</div>
-      <div><strong>File Name: </strong>{gameStatus.file.name}</div>
-    </div>}
-  </div>
+  return (
+    <div style={{ flex: 1 }}>
+      {gameStatus.status === "downloading" && (
+        <div className="game-card-download-info">
+          <strong>Downloading</strong>
+          <div>
+            <strong>Download URL: </strong>
+            {gameStatus.url}
+          </div>
+          <div>
+            <strong>Bytes Received: </strong>
+            {gameStatus.bytesReceived}
+          </div>
+          <div>
+            <strong>Bytes Total: </strong>
+            {gameStatus.bytesTotal}
+          </div>
+          <div>
+            <strong>Speed: </strong>
+            {gameStatus.speed}
+          </div>
+          <div>
+            <strong>Percent: </strong>
+            {gameStatus.percent.toFixed(2)}%
+          </div>
+          <ul>
+            {gameStatus.files
+              .filter(info => info.percent !== 100 && info.percent !== 0)
+              .map((file, index) => (
+                <li key={index}>
+                  <div>
+                    <strong>File: </strong>
+                    {file.url}
+                  </div>
+                  <div>
+                    <strong>Bytes Received: </strong>
+                    {file.bytesReceived}
+                  </div>
+                  <div>
+                    <strong>Bytes Total: </strong>
+                    {file.bytesTotal}
+                  </div>
+                  <div>
+                    <strong>Percent: </strong>
+                    {file.percent.toFixed(2)}%
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+      {gameStatus.status === "installing" && (
+        <div className="game-card-download-info">
+          <strong>Installing</strong>
+          <div>
+            <strong>Filename:</strong> {gameStatus.installingFile}
+          </div>
+        </div>
+      )}
+      {gameStatus.status === "pushing app data" && (
+        <div className="game-card-download-info">
+          <strong>Pusing App Data</strong>
+          <div>
+            <strong>Files:</strong>
+            {gameStatus.file.index + 1}/{gameStatus.totalFiles}
+          </div>
+          <div>
+            <strong>File Name: </strong>
+            {gameStatus.file.name}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default GameVerboseInfo;

--- a/src/react/components/Icons.ts
+++ b/src/react/components/Icons.ts
@@ -1,10 +1,10 @@
-import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import * as solid from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import * as solid from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon as Icon } from "@fortawesome/react-fontawesome";
 
 export const Icons = { solid };
 export type { IconDefinition };
-export default Icon
+export default Icon;
 
 type IconList = typeof solid;
 type IconKey = keyof IconList;
@@ -14,24 +14,19 @@ interface IconSearchName {
   lowerCaseName: string;
 }
 
-
 export function getIconByCaseInsensitiveName(name: string): IconDefinition {
-  const normalizedName = ICON_NAME_PREFIX + name.toLowerCase().replace('-', '');
-  const foundIcon = iconNames.find(iconName =>
-    iconName.lowerCaseName === normalizedName
-  )?.icon;
-  
+  const normalizedName = ICON_NAME_PREFIX + name.toLowerCase().replace("-", "");
+  const foundIcon = iconNames.find(iconName => iconName.lowerCaseName === normalizedName)?.icon;
+
   return foundIcon ? foundIcon : Icons.solid.faQuestion;
 }
 
-const iconNames: IconSearchName[] = [
-  ...mapIconPack(Icons.solid)
-];
+const iconNames: IconSearchName[] = [...mapIconPack(Icons.solid)];
 const ICON_NAME_PREFIX = "fa";
 
 function mapIconPack(pack: IconList): IconSearchName[] {
   return Object.keys(pack).map((iconName: string) => ({
     icon: pack[iconName as IconKey] as IconDefinition,
-    lowerCaseName: iconName.toLowerCase()
+    lowerCaseName: iconName.toLowerCase(),
   }));
 }

--- a/src/react/components/TabBar.tsx
+++ b/src/react/components/TabBar.tsx
@@ -1,21 +1,21 @@
-import { CSSProperties } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { CSSProperties } from "react";
+import { Link, useLocation } from "react-router-dom";
 
-import Icon, { IconDefinition, Icons } from './Icons';
+import Icon, { IconDefinition, Icons } from "./Icons";
 
 interface Tab {
-    name: string;
-    path: string;
-    icon: IconDefinition;
-    isFlexible?: boolean;
+  name: string;
+  path: string;
+  icon: IconDefinition;
+  isFlexible?: boolean;
 }
 
 const tabs: Tab[] = [
-  { name: 'Games', path: '/games', icon: Icons.solid.faGamepad, isFlexible: true },
-  { name: 'Library', path: '/downloads', icon: Icons.solid.faLayerGroup, isFlexible: true },
-  { name: 'Devices', path: '/devices', icon: Icons.solid.faTabletAlt, isFlexible: true },
+  { name: "Games", path: "/games", icon: Icons.solid.faGamepad, isFlexible: true },
+  { name: "Library", path: "/downloads", icon: Icons.solid.faLayerGroup, isFlexible: true },
+  { name: "Devices", path: "/devices", icon: Icons.solid.faTabletAlt, isFlexible: true },
   // { name: 'Users', path: '/users', icon: Icons.solid.faUsers, isFlexible: true },
-  { name: 'Settings', path: '/settings', icon: Icons.solid.faCog, isFlexible: false },
+  { name: "Settings", path: "/settings", icon: Icons.solid.faCog, isFlexible: false },
 ];
 
 const TabBar: React.FC = () => {
@@ -23,7 +23,7 @@ const TabBar: React.FC = () => {
 
   return (
     <div style={styles.container}>
-      {tabs.map((tab) => (
+      {tabs.map(tab => (
         <Link
           key={tab.path}
           to={tab.path}
@@ -43,35 +43,35 @@ const TabBar: React.FC = () => {
 
 const styles: { [key: string]: CSSProperties } = {
   container: {
-    display: 'flex',
-    flexDirection: 'row',
-    height: '70px',
-    minHeight: '70px',
-    backgroundColor: '#2c3e50',
-    borderTop: '1px solid #34495e',
+    display: "flex",
+    flexDirection: "row",
+    height: "70px",
+    minHeight: "70px",
+    backgroundColor: "#2c3e50",
+    borderTop: "1px solid #34495e",
   },
   tab: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textDecoration: 'none',
-    color: '#ecf0f1',
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    textDecoration: "none",
+    color: "#ecf0f1",
   },
   flexibleTab: {
     flex: 1,
   },
   nonFlexibleTab: {
-    flex: 'none',
-    width: '90px',
-    backgroundColor: '#777', 
+    flex: "none",
+    width: "90px",
+    backgroundColor: "#777",
   },
   activeTab: {
-    backgroundColor: '#34495e',
+    backgroundColor: "#34495e",
   },
   tabText: {
-    fontSize: '12px',
-    marginTop: '4px',
+    fontSize: "12px",
+    marginTop: "4px",
   },
 };
 

--- a/src/react/components/ToggleView.tsx
+++ b/src/react/components/ToggleView.tsx
@@ -8,7 +8,7 @@ interface ToggleViewProps {
   onToggle?: (isGrid: boolean) => void;
 }
 
-const ToggleView = ({ onToggle, value = true}: ToggleViewProps) => {
+const ToggleView = ({ onToggle, value = true }: ToggleViewProps) => {
   const [isGrid, setIsGrid] = useState<boolean>(value);
 
   const toggleView = () => {
@@ -17,11 +17,13 @@ const ToggleView = ({ onToggle, value = true}: ToggleViewProps) => {
     onToggle?.(newView);
   };
 
-  return <div className="toggle-container" onClick={toggleView} role="button" aria-label="Toggle view">
-    <Icon icon={Icons.solid.faTable} className={`toggle-icon ${isGrid ? "selected" : ""}`} />
-    <div className="divider"></div>
-    <Icon icon={Icons.solid.faList} className={`toggle-icon ${!isGrid ? "selected" : ""}`} />
-  </div>
+  return (
+    <div className="toggle-container" onClick={toggleView} role="button" aria-label="Toggle view">
+      <Icon icon={Icons.solid.faTable} className={`toggle-icon ${isGrid ? "selected" : ""}`} />
+      <div className="divider"></div>
+      <Icon icon={Icons.solid.faList} className={`toggle-icon ${!isGrid ? "selected" : ""}`} />
+    </div>
+  );
 };
 
 export default ToggleView;

--- a/src/react/components/UsersList.tsx
+++ b/src/react/components/UsersList.tsx
@@ -11,9 +11,10 @@ const UsersList: React.FC<{ users: User[] }> = ({ users }) => {
     <div className="users-list">
       <h2>Users</h2>
       <ul>
-        {users.map((user) => (
+        {users.map(user => (
           <li key={user.id}>
-            <strong>{user.name}</strong> (ID: {user.id}) - {user.running ? "Running" : "Not Running"}
+            <strong>{user.name}</strong> (ID: {user.id}) -{" "}
+            {user.running ? "Running" : "Not Running"}
           </li>
         ))}
       </ul>

--- a/src/react/pages/Devices.tsx
+++ b/src/react/pages/Devices.tsx
@@ -1,26 +1,28 @@
-import React, { useEffect } from 'react';
+import React, { useEffect } from "react";
 
-import deviceManager from '@bridge/devices';
-import gamesManager from '@bridge/games';
-import Button from '@components/Button';
-import DeviceInfoCard from '@components/DeviceInfoCard';
-import DevicesList from '@components/DeviceList';
-import GameCard from '@components/GameCard';
-import Icon, { Icons } from '@components/Icons';
-import UsersList from '@components/UsersList';
-import { CenteredLoading } from './Loading';
+import deviceManager from "@bridge/devices";
+import gamesManager from "@bridge/games";
+import Button from "@components/Button";
+import DeviceInfoCard from "@components/DeviceInfoCard";
+import DevicesList from "@components/DeviceList";
+import GameCard from "@components/GameCard";
+import Icon, { Icons } from "@components/Icons";
+import UsersList from "@components/UsersList";
+import { CenteredLoading } from "./Loading";
 
-import type { AdbCommandOutput } from '@bridge/devices';
-import type { Game } from '@bridge/games';
+import type { AdbCommandOutput } from "@bridge/devices";
+import type { Game } from "@bridge/games";
 
-const LAST_IP_KEY = 'device.lastIp';
+const LAST_IP_KEY = "device.lastIp";
 
 const Devices: React.FC = () => {
-  const [result, setResult] = React.useState<AdbCommandOutput['list']>(deviceManager.getDevicesCache());
+  const [result, setResult] = React.useState<AdbCommandOutput["list"]>(
+    deviceManager.getDevicesCache()
+  );
   const [loading, setLoading] = React.useState<boolean>(true);
-  const [connectIp, setConnectIp] = React.useState<string>(localStorage.getItem(LAST_IP_KEY) || '');
-  const [pairIp, setPairIp] = React.useState<string>('');
-  const [pairCode, setPairCode] = React.useState<string>('');
+  const [connectIp, setConnectIp] = React.useState<string>(localStorage.getItem(LAST_IP_KEY) || "");
+  const [pairIp, setPairIp] = React.useState<string>("");
+  const [pairCode, setPairCode] = React.useState<string>("");
 
   const getDevices = async (serial?: string) => {
     if (serial) {
@@ -29,90 +31,156 @@ const Devices: React.FC = () => {
     setLoading(true);
     const devices = await deviceManager.getDevices();
     setResult(devices);
-    setLoading(false)
+    setLoading(false);
   };
 
   const connectionFeedback = async (task: Promise<any>, message: string) => {
     setLoading(true);
     const result = await task;
     const devices = getDevices();
-    if(!result) {
+    if (!result) {
       alert(message);
     }
     await devices;
     setLoading(false);
-  }
+  };
 
   const connectWifi = async (serial: string) => {
-    connectionFeedback(deviceManager.connectWifi(serial), 'Failed to connect with tcp to device ' + serial);
-  }
+    connectionFeedback(
+      deviceManager.connectWifi(serial),
+      "Failed to connect with tcp to device " + serial
+    );
+  };
 
   const connectTcp = async (connectIp: string) => {
     localStorage.setItem(LAST_IP_KEY, connectIp);
-    connectionFeedback(deviceManager.connectTcp(connectIp), 'Failed to connect to address' + connectIp);
-  }
+    connectionFeedback(
+      deviceManager.connectTcp(connectIp),
+      "Failed to connect to address" + connectIp
+    );
+  };
 
   const pair = async (pairIp: string, pairCode: string) => {
     connectionFeedback(
       deviceManager.pair(pairIp, pairCode),
-      'Failed to pair with device ' + pairIp + ' and code ' + pairCode +
-      '. But maybe it is already paired.'
+      "Failed to pair with device " +
+        pairIp +
+        " and code " +
+        pairCode +
+        ". But maybe it is already paired."
     );
-  }
+  };
 
   useEffect(() => {
-    getDevices()
+    getDevices();
     const interval = setInterval(() => {
-      getDevices()
+      getDevices();
     }, 30000);
     return () => {
       clearInterval(interval);
-    }
+    };
   }, []);
 
-  return <div>
-    <div className='horizontal-display'>
-      <h1><Icon icon={Icons.solid.faTabletAlt} size="lg" />Devices Page</h1>
-      <CenteredLoading visible={loading} />
-      <Button onClick={() => getDevices()} icon={Icons.solid.faRefresh}>Reload Devices</Button>
-    </div>
-    <div style={{padding: '0 20px'}}>
-      <h2>Network Connection</h2>
-      <strong>With address: </strong>
-      <input type="text" placeholder="0.0.0.0:5555" value={connectIp} onChange={e => setConnectIp(e.target.value)} style={{width: '11em'}} />
-      <Button onClick={() => connectTcp(connectIp)} icon={Icons.solid.faWifi}>Try Connect TCP</Button>
-    </div>
-    <div style={{padding: '0 20px'}}>
-      <strong>Pair with Code: </strong>
-      <input type="text" placeholder="0.0.0.0:5555" style={{width: '7.4em'}} value={pairIp} onChange={e => setPairIp(e.target.value)} />
-      <input type="text" placeholder="Code" style={{width: '4em'}} value={pairCode} onChange={e => setPairCode(e.target.value)} />
-      <Button onClick={() => pair(pairIp, pairCode)} icon={Icons.solid.faWifi}>Try Pair</Button>
-      <a href="https://developer.android.com/tools/adb?hl=pt-br#connect-to-a-device-over-wi-fi" target="_blank" rel="noreferrer">Instructions (Use Android System Configs)</a>
-    </div>
-    {result.devices.length === 0 ? <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-      <h2>No Devices Found</h2>
-    </div> : <div style={{padding: '0 20px'}}>
-      <DevicesList devices={result.devices} onConnect={getDevices} onConnectWifi={connectWifi} />
-      {result.deviceInfo && <DeviceInfoCard deviceInfo={result.deviceInfo} />}
-      <UsersList users={result.users} />
-      <h2>Installed Games</h2>
-      <div className='game-list'>
-        {(result.apps
-          .map(game => gamesManager.getGameFromCache(game.packageName))
-          .filter(game => game) as Game[])
-          .map(game => <GameCard game={game} key={game.id}/>)}
+  return (
+    <div>
+      <div className="horizontal-display">
+        <h1>
+          <Icon icon={Icons.solid.faTabletAlt} size="lg" />
+          Devices Page
+        </h1>
+        <CenteredLoading visible={loading} />
+        <Button onClick={() => getDevices()} icon={Icons.solid.faRefresh}>
+          Reload Devices
+        </Button>
       </div>
-      <h2>Other Installed Apps</h2>
-      <ul>
-        {result.apps
-          .filter(game => !gamesManager.getGameFromCache(game.packageName))
-          .map(game => <li key={game.packageName}>
-            <span style={{display: 'inline-block', width: 200}}><strong>Version:</strong> {game.versionCode}</span>
-            {game.packageName}
-          </li>)}
-      </ul>
-    </div>}
-  </div>;
+      <div style={{ padding: "0 20px" }}>
+        <h2>Network Connection</h2>
+        <strong>With address: </strong>
+        <input
+          type="text"
+          placeholder="0.0.0.0:5555"
+          value={connectIp}
+          onChange={e => setConnectIp(e.target.value)}
+          style={{ width: "11em" }}
+        />
+        <Button onClick={() => connectTcp(connectIp)} icon={Icons.solid.faWifi}>
+          Try Connect TCP
+        </Button>
+      </div>
+      <div style={{ padding: "0 20px" }}>
+        <strong>Pair with Code: </strong>
+        <input
+          type="text"
+          placeholder="0.0.0.0:5555"
+          style={{ width: "7.4em" }}
+          value={pairIp}
+          onChange={e => setPairIp(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Code"
+          style={{ width: "4em" }}
+          value={pairCode}
+          onChange={e => setPairCode(e.target.value)}
+        />
+        <Button onClick={() => pair(pairIp, pairCode)} icon={Icons.solid.faWifi}>
+          Try Pair
+        </Button>
+        <a
+          href="https://developer.android.com/tools/adb?hl=pt-br#connect-to-a-device-over-wi-fi"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Instructions (Use Android System Configs)
+        </a>
+      </div>
+      {result.devices.length === 0 ? (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100%",
+          }}
+        >
+          <h2>No Devices Found</h2>
+        </div>
+      ) : (
+        <div style={{ padding: "0 20px" }}>
+          <DevicesList
+            devices={result.devices}
+            onConnect={getDevices}
+            onConnectWifi={connectWifi}
+          />
+          {result.deviceInfo && <DeviceInfoCard deviceInfo={result.deviceInfo} />}
+          <UsersList users={result.users} />
+          <h2>Installed Games</h2>
+          <div className="game-list">
+            {(
+              result.apps
+                .map(game => gamesManager.getGameFromCache(game.packageName))
+                .filter(game => game) as Game[]
+            ).map(game => (
+              <GameCard game={game} key={game.id} />
+            ))}
+          </div>
+          <h2>Other Installed Apps</h2>
+          <ul>
+            {result.apps
+              .filter(game => !gamesManager.getGameFromCache(game.packageName))
+              .map(game => (
+                <li key={game.packageName}>
+                  <span style={{ display: "inline-block", width: 200 }}>
+                    <strong>Version:</strong> {game.versionCode}
+                  </span>
+                  {game.packageName}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default Devices;

--- a/src/react/pages/GameDetailsPage.tsx
+++ b/src/react/pages/GameDetailsPage.tsx
@@ -1,23 +1,34 @@
-import React from 'react';
+import React from "react";
 import "./Games.css";
 
-import type { Game } from '@bridge/games';
+import type { Game } from "@bridge/games";
 
-import downloadManager from '@bridge/download';
-import GameCard from '@components/GameCard';
+import downloadManager from "@bridge/download";
+import GameCard from "@components/GameCard";
 
 interface GameDetailsPageProps {
   game: Game;
 }
 
-const GameDetailsPage: React.FC<GameDetailsPageProps> = ({game}: GameDetailsPageProps) => {
-
-  return <>
-    <h1 style={{textAlign: 'center'}}>{game.name}</h1>
-    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'start', justifyContent: 'space-between', flexWrap: 'wrap', gap: 35, padding: 25 }}>
-      <GameCard game={game} onDownload={() => downloadManager.downloadGame(game.id)} verbose />
-    </div>
-  </>
+const GameDetailsPage: React.FC<GameDetailsPageProps> = ({ game }: GameDetailsPageProps) => {
+  return (
+    <>
+      <h1 style={{ textAlign: "center" }}>{game.name}</h1>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "start",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 35,
+          padding: 25,
+        }}
+      >
+        <GameCard game={game} onDownload={() => downloadManager.downloadGame(game.id)} verbose />
+      </div>
+    </>
+  );
 };
 
 export default GameDetailsPage;

--- a/src/react/pages/Games.tsx
+++ b/src/react/pages/Games.tsx
@@ -1,16 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import "./Games.css";
 
-import downloadManager from '@bridge/download';
-import gamesManager from '@bridge/games';
-import GameCard from '@components/GameCard';
-import Icon, { Icons } from '@components/Icons';
-import ToggleView from '@components/ToggleView';
-import GameDetailsPage from './GameDetailsPage';
-import { CenteredLoading } from './Loading';
+import downloadManager from "@bridge/download";
+import gamesManager from "@bridge/games";
+import GameCard from "@components/GameCard";
+import Icon, { Icons } from "@components/Icons";
+import ToggleView from "@components/ToggleView";
+import GameDetailsPage from "./GameDetailsPage";
+import { CenteredLoading } from "./Loading";
 
-import type { Game } from '@bridge/games';
+import type { Game } from "@bridge/games";
 
 const Games: React.FC = () => {
   const [result, setResult] = useState<Game[]>(gamesManager.getCache());
@@ -24,7 +24,7 @@ const Games: React.FC = () => {
 
   const getAdbDevices = async () => {
     setLoading(true);
-  
+
     setResult(await gamesManager.getGames());
     setLoading(false);
   };
@@ -34,39 +34,51 @@ const Games: React.FC = () => {
   }, []);
 
   if (result.length > 0 && id) {
-    return <GameDetailsPage game={result.find(game => game.id === id)!} />
+    return <GameDetailsPage game={result.find(game => game.id === id)!} />;
   }
 
-  return <>
-    <div className="game-list-header">
-      <Icon icon={Icons.solid.faSearch} size='xl' />
-      <input type="text" value={search} onChange={e => setSearch(e.target.value)} style={{ flex: 1 }} placeholder='Search' />
-      <CenteredLoading visible={result.length === 0 || loading} />
-      <ToggleView onToggle={setIsGrid} />
-      <strong>Limit:</strong><select onChange={e => setLimit(Number.parseInt(e.target.value))} value={`${limit}`}>
-        <option value="10">10</option>
-        <option value="50">50</option>
-        <option value="100">100</option>
-        <option value="250">250</option>
-        <option value="500">500</option>
-        <option value="1000">1000</option>
-        <option value="10000">All (Not Recomended)</option>
-      </select>
-    </div>
-    <div className={'game-list' + (isGrid ? '' : ' list')}>
-      {result
-        .map((game) => searchItemIsIncluded(search, game))
-        .sort((a, b) => b.relevance - a.relevance)
-        .filter(item => item.relevance > 0)
-        .filter((_, i) => i < limit)
-        .map((item) => item.game)
-        .map((game) =>
-          <GameCard
-            key={game.id} game={game} onSelect={game => navigate(game.id ?? "")}
-            onDownload={() => downloadManager.downloadGame(game.id)} />
-        )}
-    </div>
-  </>
+  return (
+    <>
+      <div className="game-list-header">
+        <Icon icon={Icons.solid.faSearch} size="xl" />
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ flex: 1 }}
+          placeholder="Search"
+        />
+        <CenteredLoading visible={result.length === 0 || loading} />
+        <ToggleView onToggle={setIsGrid} />
+        <strong>Limit:</strong>
+        <select onChange={e => setLimit(Number.parseInt(e.target.value))} value={`${limit}`}>
+          <option value="10">10</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+          <option value="250">250</option>
+          <option value="500">500</option>
+          <option value="1000">1000</option>
+          <option value="10000">All (Not Recomended)</option>
+        </select>
+      </div>
+      <div className={"game-list" + (isGrid ? "" : " list")}>
+        {result
+          .map(game => searchItemIsIncluded(search, game))
+          .sort((a, b) => b.relevance - a.relevance)
+          .filter(item => item.relevance > 0)
+          .filter((_, i) => i < limit)
+          .map(item => item.game)
+          .map(game => (
+            <GameCard
+              key={game.id}
+              game={game}
+              onSelect={game => navigate(game.id ?? "")}
+              onDownload={() => downloadManager.downloadGame(game.id)}
+            />
+          ))}
+      </div>
+    </>
+  );
 };
 
 export default Games;
@@ -80,7 +92,7 @@ const fieldToSearch: (keyof Game)[] = [
   "id",
   "category",
   "name",
-  
+
   "normalName",
   "packageName",
   "version",
@@ -91,14 +103,17 @@ function searchItemIsIncluded(search: string, item: Game): SearchRelevance {
   const searchParts = search.split(" ");
   let relevance = 0;
 
-  fieldToSearch.forEach((field) => {
+  fieldToSearch.forEach(field => {
     const fieldValue = item[field];
     if (typeof fieldValue !== "string") return;
     const fieldParts = fieldValue.toLocaleLowerCase().split(" ");
     const fieldRelevance = searchParts.reduce((acc, searchPart) => {
-      return acc + fieldParts.reduce((acc, fieldPart) => {
-        return acc + (fieldPart.includes(searchPart) ? 1 : 0);
-      }, 0);
+      return (
+        acc +
+        fieldParts.reduce((acc, fieldPart) => {
+          return acc + (fieldPart.includes(searchPart) ? 1 : 0);
+        }, 0)
+      );
     }, 0);
     relevance += fieldRelevance;
   });

--- a/src/react/pages/Library.tsx
+++ b/src/react/pages/Library.tsx
@@ -1,75 +1,112 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 import downloadManager, { GameStatusType } from "@bridge/download";
-import gamesManager from '@bridge/games';
-import settingsManager from '@bridge/settings';
-import Button from '@components/Button';
-import GameCard from '@components/GameCard';
-import Icon, { Icons } from '@components/Icons';
+import gamesManager from "@bridge/games";
+import settingsManager from "@bridge/settings";
+import Button from "@components/Button";
+import GameCard from "@components/GameCard";
+import Icon, { Icons } from "@components/Icons";
 
-import type { Game } from '@bridge/games';
+import type { Game } from "@bridge/games";
 
 let hasPedingDownloadFolderSearch = false;
 
-const installingStates: GameStatusType[] = ['installing', 'unzipping', 'downloading', 'pushing app data', 'cancelling'];
+const installingStates: GameStatusType[] = [
+  "installing",
+  "unzipping",
+  "downloading",
+  "pushing app data",
+  "cancelling",
+];
 const Library: React.FC = () => {
   const [downloads, setDownloads] = React.useState<Game[]>([]);
   const [downloading, setDownloading] = React.useState<Game[]>([]);
   const navigate = useNavigate();
 
-
   const updateDownloadedGames = async () => {
-    if(hasPedingDownloadFolderSearch)
-      return;
+    if (hasPedingDownloadFolderSearch) return;
     const result = await downloadManager.getDownloadedGames().finally(() => {
       hasPedingDownloadFolderSearch = false;
-    })
-    setDownloads(result
-      .map(id => gamesManager.getGameFromCacheById(id))
-      .filter(game => game) as Game[]
+    });
+    setDownloads(
+      result.map(id => gamesManager.getGameFromCacheById(id)).filter(game => game) as Game[]
     );
   };
 
   const changeDownloadsDir = async () => {
     await settingsManager.setDownloadPath();
     updateDownloadedGames();
-  }
+  };
 
   useEffect(() => {
     return downloadManager.addDownloadingListener(infos => {
       updateDownloadedGames();
-      setDownloading(infos
-        .filter(info => installingStates.includes(info.status))
-        .map(({id}) => gamesManager.getGameFromCacheById(id))
-        .filter(game => game) as Game[]
+      setDownloading(
+        infos
+          .filter(info => installingStates.includes(info.status))
+          .map(({ id }) => gamesManager.getGameFromCacheById(id))
+          .filter(game => game) as Game[]
       );
     });
   }, []);
 
-  return <div>
-    <div className='horizontal-display'>
-      <h1><Icon icon={Icons.solid.faLayerGroup} size="lg" />Library Page</h1>
-      <Button onClick={changeDownloadsDir} icon={Icons.solid.faFolderOpen}>Change Downloads Dir</Button>
-    </div>
-    {downloading.length === 0 && downloads.length === 0 && <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-      <h2>No Games Found</h2>
-    </div>}
-    <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', padding: '1em' }}>
-      {downloading.length !== 0 && <div style={{flex: 1}}>
-        <h2>Downloading Games</h2>
-        <div className="game-list">
-          {downloading.map(game => <GameCard game={game} key={game.id} onSelect={() => navigate('/games/' + game.id)}/>)}
+  return (
+    <div>
+      <div className="horizontal-display">
+        <h1>
+          <Icon icon={Icons.solid.faLayerGroup} size="lg" />
+          Library Page
+        </h1>
+        <Button onClick={changeDownloadsDir} icon={Icons.solid.faFolderOpen}>
+          Change Downloads Dir
+        </Button>
+      </div>
+      {downloading.length === 0 && downloads.length === 0 && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100%",
+          }}
+        >
+          <h2>No Games Found</h2>
         </div>
-      </div>}
-      {downloads.length !== 0 && <div style={{flex: 1}}>
-        <h2>Downloaded Games</h2>
-        <div className='game-list'>
-          {downloads.map(game => <GameCard downloaded game={game} key={game.id} onSelect={() => navigate('/games/' + game.id)}/>)}
-        </div>
-      </div>}
+      )}
+      <div style={{ display: "flex", flexDirection: "row", flexWrap: "wrap", padding: "1em" }}>
+        {downloading.length !== 0 && (
+          <div style={{ flex: 1 }}>
+            <h2>Downloading Games</h2>
+            <div className="game-list">
+              {downloading.map(game => (
+                <GameCard
+                  game={game}
+                  key={game.id}
+                  onSelect={() => navigate("/games/" + game.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+        {downloads.length !== 0 && (
+          <div style={{ flex: 1 }}>
+            <h2>Downloaded Games</h2>
+            <div className="game-list">
+              {downloads.map(game => (
+                <GameCard
+                  downloaded
+                  game={game}
+                  key={game.id}
+                  onSelect={() => navigate("/games/" + game.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
-  </div>;
+  );
 };
 
 export default Library;

--- a/src/react/pages/Loading.tsx
+++ b/src/react/pages/Loading.tsx
@@ -6,17 +6,24 @@ interface LoadingProps {
 }
 
 export const BasicLoading: React.FC<LoadingProps> = ({ visible }: LoadingProps) => {
-  return <div className={
-    `lds-ellipsis` + (visible === true ? '' : ' hide')
-  }>
-    <div>
-      <div></div><div></div><div></div><div></div>
+  return (
+    <div className={`lds-ellipsis` + (visible === true ? "" : " hide")}>
+      <div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
     </div>
-  </div>;
-}
+  );
+};
 
 export const CenteredLoading: React.FC<LoadingProps> = ({ visible }: LoadingProps) => {
-  return <div style={{ display: visible?"flex":"none", justifyContent: "center", alignItems: "center" }}>
-    <BasicLoading visible={visible} />
-  </div>;
-}
+  return (
+    <div
+      style={{ display: visible ? "flex" : "none", justifyContent: "center", alignItems: "center" }}
+    >
+      <BasicLoading visible={visible} />
+    </div>
+  );
+};

--- a/src/react/pages/Settings.tsx
+++ b/src/react/pages/Settings.tsx
@@ -1,32 +1,35 @@
-import React, { useEffect, useState } from 'react';
-import { BasicLoading } from './Loading';
-import './Settings.css';
+import React, { useEffect, useState } from "react";
+import { BasicLoading } from "./Loading";
+import "./Settings.css";
 
-import { isElectron, isWebsoket } from '@bridge';
-import settingsManager, { SystemHelth } from '@bridge/settings';
-import Button from '@components/Button';
-import Icon, { Icons } from '@components/Icons';
+import { isElectron, isWebsoket } from "@bridge";
+import settingsManager, { SystemHelth } from "@bridge/settings";
+import Button from "@components/Button";
+import Icon, { Icons } from "@components/Icons";
 
-import type { RepoDownloadsInfo, Settings as SettingsModel } from '@bridge/settings';
+import type { RepoDownloadsInfo, Settings as SettingsModel } from "@bridge/settings";
 
-let sysTemHelthCache: SystemHelth|null = null;
-const loadSystemHelth = async () => settingsManager.getHelthInfo().then(info => {
-  sysTemHelthCache = info;
-  return info;
-});
+let sysTemHelthCache: SystemHelth | null = null;
+const loadSystemHelth = async () =>
+  settingsManager.getHelthInfo().then(info => {
+    sysTemHelthCache = info;
+    return info;
+  });
 loadSystemHelth();
 
 export const changeDownloadsDir = async (): Promise<SettingsModel> => {
   if (isWebsoket) {
-    alert('Use ROOKIE_DOWNLOADS_DIR environment variable with a valid full path to set the download dir on web server');
+    alert(
+      "Use ROOKIE_DOWNLOADS_DIR environment variable with a valid full path to set the download dir on web server"
+    );
   }
   return await settingsManager.setDownloadPath();
 };
 
 const Settings: React.FC = () => {
   const [infos, set] = useState<RepoDownloadsInfo>(settingsManager.getReposInfo());
-  const [update, setUpdate] = useState<string|null>(null);
-  const [systemHelth, setSystemHelth] = useState<SystemHelth|null>(sysTemHelthCache);
+  const [update, setUpdate] = useState<string | null>(null);
+  const [systemHelth, setSystemHelth] = useState<SystemHelth | null>(sysTemHelthCache);
   const [settings, setSettings] = useState<SettingsModel>({});
 
   const openDevTools = () => {
@@ -34,8 +37,10 @@ const Settings: React.FC = () => {
   };
 
   useEffect(() => {
-    settingsManager.fetchReposInfo().then(info => {set({...info})});
-    if(!systemHelth) {
+    settingsManager.fetchReposInfo().then(info => {
+      set({ ...info });
+    });
+    if (!systemHelth) {
       loadSystemHelth().then(setSystemHelth);
     }
     settingsManager.getSettings().then(setSettings);
@@ -47,59 +52,121 @@ const Settings: React.FC = () => {
   const totalDownloads = reposInfos.reduce((acc, { total }) => acc + total, 0);
   const lastUpdate = new Date(Math.max(...reposInfos.map(({ lastUpdate }) => lastUpdate)));
 
-  return <div className='settings'>
-    <div className='horizontal-display'>
-      <h1><Icon icon={Icons.solid.faGear} size="lg" />Settings Page</h1>
-      <div className='spacer' />
-      {isElectron && <Button onClick={openDevTools} icon={Icons.solid.faTools}>DevTools</Button>}
-      <Button onClick={() => changeDownloadsDir().then(setSettings)} icon={Icons.solid.faFolderOpen}>Change Downloads Dir</Button>
+  return (
+    <div className="settings">
+      <div className="horizontal-display">
+        <h1>
+          <Icon icon={Icons.solid.faGear} size="lg" />
+          Settings Page
+        </h1>
+        <div className="spacer" />
+        {isElectron && (
+          <Button onClick={openDevTools} icon={Icons.solid.faTools}>
+            DevTools
+          </Button>
+        )}
+        <Button
+          onClick={() => changeDownloadsDir().then(setSettings)}
+          icon={Icons.solid.faFolderOpen}
+        >
+          Change Downloads Dir
+        </Button>
+      </div>
+      <div className="sections">
+        <section>
+          <h2>Settings</h2>
+          {Object.keys(settings).map(key => {
+            const value = (settings as any)[key];
+            return (
+              <div key={key}>
+                <strong>{key}</strong>: {value}
+              </div>
+            );
+          })}
+        </section>
+        <section>
+          <h2>System Helth Check</h2>
+          {systemHelth ? (
+            <ul>
+              <li>
+                <pre>
+                  <strong>App Version:</strong> {systemHelth.appVersion}
+                  {isWebsoket ? " (Web Version)" : ""}
+                </pre>
+              </li>
+              {isElectron && (
+                <li>
+                  <pre>
+                    <strong>Electron Version:</strong> {systemHelth.electronVersion}
+                  </pre>
+                </li>
+              )}
+              <li>
+                <pre>
+                  <strong>{isElectron && "Bundled "}Node Version:</strong>{" "}
+                  {systemHelth.bundledNodeVersion}
+                </pre>
+              </li>
+              <li>
+                <pre>
+                  <strong>ADB:</strong> {systemHelth.adb}
+                </pre>
+              </li>
+              <li>
+                <pre>
+                  <strong>7Zip:</strong> {systemHelth.sevenZip}
+                </pre>
+              </li>
+              <li>
+                <pre>
+                  <strong>Unzip:</strong> {systemHelth.unzip}
+                </pre>
+              </li>
+              <li>
+                <pre>
+                  <strong>Java:</strong> {systemHelth.java}
+                </pre>
+              </li>
+            </ul>
+          ) : (
+            <BasicLoading visible={!systemHelth} />
+          )}
+        </section>
+        {update && (
+          <section>
+            <h2>Update Available</h2>
+            <a href={update} target="_blank" rel="noreferrer">
+              {update}
+            </a>
+          </section>
+        )}
+        <section>
+          <h2>Rookie Total Downloads: {totalDownloads}</h2>
+          {reposInfos.map(({ byExt, name, total, lastAppVersion }) => {
+            return (
+              <div key={name}>
+                <strong>
+                  {name} ({total})
+                </strong>{" "}
+                Last Version: {lastAppVersion}
+                <div className="tags">
+                  {Object.entries(byExt)
+                    .filter(([, count]) => count > 0)
+                    .sort(([ext], [ext2]) => ext.localeCompare(ext2))
+                    .map(([ext, count]) => (
+                      <span key={ext}>
+                        {ext} ({count})
+                      </span>
+                    ))}
+                </div>
+              </div>
+            );
+          })}
+          <p>Info Updated at: {lastUpdate.toLocaleString()}</p>
+        </section>
+      </div>
     </div>
-    <div className='sections'>
-      <section>
-        <h2>Settings</h2>
-        {Object.keys(settings).map(key => {
-          const value = (settings as any)[key];
-          return <div key={key}>
-            <strong>{key}</strong>: {value}
-          </div>;
-        })}
-      </section>
-      <section>
-        <h2>System Helth Check</h2>
-        {systemHelth ? <ul>
-          <li><pre><strong>App Version:</strong> {systemHelth.appVersion}{isWebsoket? ' (Web Version)' : ''}</pre></li>
-          {isElectron && <li><pre><strong>Electron Version:</strong> {systemHelth.electronVersion}</pre></li>}
-          <li><pre><strong>{isElectron && 'Bundled '}Node Version:</strong> {systemHelth.bundledNodeVersion}</pre></li>
-          <li><pre><strong>ADB:</strong> {systemHelth.adb}</pre></li>
-          <li><pre><strong>7Zip:</strong> {systemHelth.sevenZip}</pre></li>
-          <li><pre><strong>Unzip:</strong> {systemHelth.unzip}</pre></li>
-          <li><pre><strong>Java:</strong> {systemHelth.java}</pre></li>
-        </ul> : <BasicLoading visible={!systemHelth} />}
-      </section>
-      {update && <section>
-        <h2>Update Available</h2>
-        <a href={update} target='_blank' rel='noreferrer'>{update}</a>
-      </section>}
-      <section>
-        <h2>Rookie Total Downloads: {totalDownloads}</h2>
-        {reposInfos.map(({byExt, name, total, lastAppVersion}) => {
-          return <div key={name}>
-            <strong>{name} ({total})</strong> Last Version: {lastAppVersion}
-            <div className='tags'>
-              {Object.entries(byExt)
-                .filter(([,count]) => count > 0)
-                .sort(([ext], [ext2]) => ext.localeCompare(ext2))
-                .map(([ext, count]) => (
-                  <span key={ext}>{ext} ({count})</span>
-                ))
-              }
-            </div>
-          </div>;
-        })}
-        <p>Info Updated at: {lastUpdate.toLocaleString()}</p>
-      </section>
-    </div>
-  </div>;
+  );
 };
 
 export default Settings;

--- a/src/react/pages/Users.tsx
+++ b/src/react/pages/Users.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const Users: React.FC = () => {
   return (

--- a/src/react/setupTests.ts
+++ b/src/react/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";

--- a/src/server/comands/adb/index.ts
+++ b/src/server/comands/adb/index.ts
@@ -1,23 +1,28 @@
 import { Command, CommandEvent } from "@comands/types";
 import AdbManager from "./manager";
 
-export type AdbCommandName = 'adb';
+export type AdbCommandName = "adb";
 export type AdbCommand = Command<AdbCommandInput, AdbCommandOutputs, AdbCommandName>;
-export type AdbCommandEvent = CommandEvent<AdbCommandInput, AdbCommandName>
-export type AdbCommandInput = { 
-  command: 'selectDevice';
-  serial: string;
-} | {
-  command: 'connectWifi';
-  serial: string;
-} | {
-  command: 'connectTcp';
-  address: string;
-} | {
-  command: 'pair';
-  address: string;
-  code: string;
-} | void
+export type AdbCommandEvent = CommandEvent<AdbCommandInput, AdbCommandName>;
+export type AdbCommandInput =
+  | {
+      command: "selectDevice";
+      serial: string;
+    }
+  | {
+      command: "connectWifi";
+      serial: string;
+    }
+  | {
+      command: "connectTcp";
+      address: string;
+    }
+  | {
+      command: "pair";
+      address: string;
+      code: string;
+    }
+  | void;
 
 export type Device = {
   serial: string;
@@ -27,21 +32,21 @@ export type Device = {
   androidVersion?: string;
   sdkVersion?: number;
   spaceUsage?: {
-      total: number;
-      used: number;
+    total: number;
+    used: number;
   };
-}
+};
 
 export type User = {
   id: number;
   name: string;
   running: boolean;
-}
+};
 
 export type AppInfo = {
   packageName: string;
   versionCode: number;
-}
+};
 
 export type AdbCommandOutput = {
   list: {
@@ -49,27 +54,25 @@ export type AdbCommandOutput = {
     deviceInfo?: Device;
     users: User[];
     apps: AppInfo[];
-  }
-}
+  };
+};
 
-type AdbCommandOutputs = 
-  AdbCommandOutput['list'] | void | string | null | boolean
-;
+type AdbCommandOutputs = AdbCommandOutput["list"] | void | string | null | boolean;
 
 export default {
-  type: 'adb',
+  type: "adb",
   receiver: async function (payload: AdbCommandInput): Promise<AdbCommandOutputs> {
-    if (payload?.command === 'selectDevice') { 
+    if (payload?.command === "selectDevice") {
       AdbManager.selectDevice(payload.serial);
       return;
-    } else if(payload?.command === 'connectWifi') {
-      return await AdbManager.connectWifi(payload.serial);;
-    } else if(payload?.command === 'connectTcp') {
+    } else if (payload?.command === "connectWifi") {
+      return await AdbManager.connectWifi(payload.serial);
+    } else if (payload?.command === "connectTcp") {
       return await AdbManager.connectTcp(payload.address);
-    } else if(payload?.command === 'pair') {
-      return await AdbManager.pair(payload.address, payload.code)
+    } else if (payload?.command === "pair") {
+      return await AdbManager.pair(payload.address, payload.code);
     }
-    
+
     const devices = await AdbManager.listDevices();
     const promises = {
       deviceInfo: AdbManager.getDeviceInfo(),
@@ -84,9 +87,9 @@ export default {
         }
         return device;
       }),
-      deviceInfo: await promises.deviceInfo || undefined,
+      deviceInfo: (await promises.deviceInfo) || undefined,
       users: await promises.users,
       apps: await promises.apps,
-    }
-  }
+    };
+  },
 } as AdbCommand;

--- a/src/server/comands/adb/manager.ts
+++ b/src/server/comands/adb/manager.ts
@@ -6,11 +6,11 @@ import SystemProcess from "@server/systemProcess";
 import type { AppInfo, Device, User } from ".";
 
 class AdbManager extends SystemProcess {
-  private currentDevice: Device|null = null;
+  private currentDevice: Device | null = null;
   private devices: Device[] = [];
   private users: User[] = [];
   private apps: AppInfo[] = [];
-  public serial: string|null = null;
+  public serial: string | null = null;
 
   constructor() {
     super();
@@ -22,8 +22,8 @@ class AdbManager extends SystemProcess {
     return stdout;
   }
 
-  private getDeviceSerial(): string|undefined {
-    if(!(this.serial && this.devices.find((device) => device.serial === this.serial))) {
+  private getDeviceSerial(): string | undefined {
+    if (!(this.serial && this.devices.find(device => device.serial === this.serial))) {
       this.selectDevice(this.devices[0]?.serial);
     }
     return this.serial || undefined;
@@ -39,8 +39,8 @@ class AdbManager extends SystemProcess {
     const output = await this.runAdbCommand(["devices"]);
     const lines = output.split("\n").slice(1);
     return lines
-      .filter((line) => line.includes("\tdevice"))
-      .map((line) => {
+      .filter(line => line.includes("\tdevice"))
+      .map(line => {
         const [serial] = line.split("\t");
         return serial.trim();
       });
@@ -48,41 +48,50 @@ class AdbManager extends SystemProcess {
 
   public async listDevices(): Promise<Device[]> {
     const serials = await this.getSerials();
-    const all = serials.map(async (serial) => ({ 
+    const all = serials.map(async serial => ({
       serial,
       ip: await this.getIp(serial),
-      model: 
-        this.devices.find((device) => device.serial === serial)?.model ||
-        await this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.product.model"])
+      model:
+        this.devices.find(device => device.serial === serial)?.model ||
+        (await this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.product.model"])),
     }));
 
-    this.devices = (await Promise.all(all)).map((device) => ({
-      ...(this.devices.find((d) => d.serial === device.serial) || {}),
+    this.devices = (await Promise.all(all)).map(device => ({
+      ...(this.devices.find(d => d.serial === device.serial) || {}),
       ...device,
     }));
 
     const serial = this.getDeviceSerial();
-    this.currentDevice = this.devices.find((device) => device.serial === serial) || null;
+    this.currentDevice = this.devices.find(device => device.serial === serial) || null;
 
     return this.devices;
   }
 
-  public async getDeviceInfo(serial?: string): Promise<Device|null> {
+  public async getDeviceInfo(serial?: string): Promise<Device | null> {
     serial = this.getDeviceSerial();
-    if (!serial) return null
+    if (!serial) return null;
 
-    const cachedDevice: Device = this.devices.find((device) => device.serial === serial) || {serial: serial};
+    const cachedDevice: Device = this.devices.find(device => device.serial === serial) || {
+      serial: serial,
+    };
 
     const ip = cachedDevice.ip || this.getIp(serial);
-    const model = cachedDevice?.model || this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.product.model"]);
-    const androidVersion = cachedDevice?.androidVersion || this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.build.version.release"]);
-    const sdkVersion = cachedDevice?.sdkVersion?.toString() || this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.build.version.sdk"]);
+    const model =
+      cachedDevice?.model ||
+      this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.product.model"]);
+    const androidVersion =
+      cachedDevice?.androidVersion ||
+      this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.build.version.release"]);
+    const sdkVersion =
+      cachedDevice?.sdkVersion?.toString() ||
+      this.runAdbCommand(["-s", serial, "shell", "getprop", "ro.build.version.sdk"]);
     const batteryOutput = this.runAdbCommand(["-s", serial, "shell", "dumpsys", "battery"]);
     const spaceUsageOutput = this.runAdbCommand(["-s", serial, "shell", "df", "/sdcard"]);
 
     const batteryLevel = parseInt((await batteryOutput)?.match(/level:\s*(\d+)/)?.[1] || "0", 10);
-    const [, total, used] = (await spaceUsageOutput).split('\n')[1]?.match(/(\d+)\s+(\d+)\s+(\d+)/) || [];
-    
+    const [, total, used] =
+      (await spaceUsageOutput).split("\n")[1]?.match(/(\d+)\s+(\d+)\s+(\d+)/) || [];
+
     cachedDevice.model = await model;
     cachedDevice.ip = await ip;
     cachedDevice.androidVersion = await androidVersion;
@@ -92,7 +101,7 @@ class AdbManager extends SystemProcess {
     return cachedDevice;
   }
 
-  private async getIp(serial: string): Promise<string|null> {
+  private async getIp(serial: string): Promise<string | null> {
     const ip = await this.runAdbCommand(["-s", serial, "shell", "ip", "route"]);
     const filteredIp = ip.match(/src\s+(\d+\.\d+\.\d+\.\d+)/)?.[1] || "";
     return filteredIp.trim().length > 0 ? filteredIp : null;
@@ -100,15 +109,15 @@ class AdbManager extends SystemProcess {
 
   public async listUsers(serial?: string): Promise<User[]> {
     serial = this.getDeviceSerial();
-    if (!serial) return []
+    if (!serial) return [];
 
     if (!this.users.length) {
       return this.users;
     }
 
     const output = await this.runAdbCommand(["-s", serial, "shell", "pm", "list", "users"]);
-    const lines = output.split("\n").filter((line) => line.includes("UserInfo"));
-    this.users = lines.map((line) => {
+    const lines = output.split("\n").filter(line => line.includes("UserInfo"));
+    this.users = lines.map(line => {
       const match = line.match(/UserInfo\{(\d+):([^:]+):/);
       return {
         id: parseInt(match?.[1] || "-1", 10),
@@ -121,23 +130,28 @@ class AdbManager extends SystemProcess {
 
   public async listPackagesForUser(serial?: string, userId: number = 0): Promise<AppInfo[]> {
     serial = this.getDeviceSerial();
-    if (!serial) return []
+    if (!serial) return [];
 
     if (this.apps.length > 0) {
       return this.apps;
     }
 
     const args = [
-      "-s", serial,
-      "shell","pm","list","packages",
-      "--user", userId.toString(),
+      "-s",
+      serial,
+      "shell",
+      "pm",
+      "list",
+      "packages",
+      "--user",
+      userId.toString(),
       "--show-versioncode",
       "-3",
-    ]
+    ];
 
     const output = await this.runAdbCommand(args);
     const lines = output.split("\n").filter(Boolean);
-    this.apps = lines.map((line) => {
+    this.apps = lines.map(line => {
       const match = line.match(/package:(\S+)\s+versionCode:(\d+)/);
       return {
         packageName: match?.[1] || "",
@@ -147,7 +161,7 @@ class AdbManager extends SystemProcess {
     return this.apps;
   }
 
-  public async connectWifi(serial: string): Promise<string|null> {
+  public async connectWifi(serial: string): Promise<string | null> {
     const ip = await this.getIp(serial);
     if (!ip) {
       log.error(new Error("Failed to get IP address"));
@@ -157,10 +171,10 @@ class AdbManager extends SystemProcess {
     return this.connectTcp(ip);
   }
 
-  public async connectTcp(address: string): Promise<string|null> {
+  public async connectTcp(address: string): Promise<string | null> {
     await this.runAdbCommand(["connect", address]);
     const serials = await this.getSerials();
-    const newSerial = serials.find((s) => s.includes(address));
+    const newSerial = serials.find(s => s.includes(address));
     if (!newSerial) {
       log.error(new Error("Failed to connect to the device" + address));
       return null;
@@ -175,68 +189,65 @@ class AdbManager extends SystemProcess {
   }
 
   public async uninstall(packageName: string) {
-    const serial = this.getDeviceSerial()
-    if (!serial)
-      throw new Error("No device selected");
+    const serial = this.getDeviceSerial();
+    if (!serial) throw new Error("No device selected");
 
-    await this.runAdbCommand([
-      "-s", serial,
-      "uninstall", packageName
-    ]);
+    await this.runAdbCommand(["-s", serial, "uninstall", packageName]);
 
-    this.apps = this.apps.filter((app) => app.packageName !== packageName);
+    this.apps = this.apps.filter(app => app.packageName !== packageName);
   }
-  
 
   public async install(apkPath: string): Promise<boolean> {
-    const serial = this.getDeviceSerial()
-    if (!serial)
-      throw new Error("No device selected");
-    if (!fs.existsSync(apkPath))
-      throw new Error("APK not found " + apkPath);
+    const serial = this.getDeviceSerial();
+    if (!serial) throw new Error("No device selected");
+    if (!fs.existsSync(apkPath)) throw new Error("APK not found " + apkPath);
 
-    await this.runAdbCommand([
-      "-s", serial,
-      "install", apkPath
-    ]);
+    await this.runAdbCommand(["-s", serial, "install", apkPath]);
 
     this.apps = [];
     return true;
   }
 
   public createObbDir(packageName: string): void {
-    const serial = this.getDeviceSerial()
-    if (!serial)
-      throw new Error("No device selected");
+    const serial = this.getDeviceSerial();
+    if (!serial) throw new Error("No device selected");
 
     this.runAdbCommand([
-      "-s", serial,
-      "shell", "mkdir", "-p", `/sdcard/Android/obb/${packageName}/`
+      "-s",
+      serial,
+      "shell",
+      "mkdir",
+      "-p",
+      `/sdcard/Android/obb/${packageName}/`,
     ]);
   }
 
   public async pushObbFile(filePath: string, packageName: string): Promise<void> {
-    const serial = this.getDeviceSerial()
-    if (!serial)
-      throw new Error("No device selected");
-    if (!fs.existsSync(filePath))
-      throw new Error("File not found " + filePath);
+    const serial = this.getDeviceSerial();
+    if (!serial) throw new Error("No device selected");
+    if (!fs.existsSync(filePath)) throw new Error("File not found " + filePath);
 
     const fileName = path.basename(filePath);
     await this.runAdbCommand([
-      "-s", serial,
-      "push", "-p", filePath, `/sdcard/Android/obb/${packageName}/${fileName}`
+      "-s",
+      serial,
+      "push",
+      "-p",
+      filePath,
+      `/sdcard/Android/obb/${packageName}/${fileName}`,
     ]);
   }
 
   public async listObbFiles(packageName: string): Promise<string[]> {
-    const serial = this.getDeviceSerial()
-    if (!serial)
-      throw new Error("No device selected");
+    const serial = this.getDeviceSerial();
+    if (!serial) throw new Error("No device selected");
 
     const output = await this.runAdbCommand([
-      "-s", serial,
-      "shell", "ls", `/sdcard/Android/obb/${packageName}/`
+      "-s",
+      serial,
+      "shell",
+      "ls",
+      `/sdcard/Android/obb/${packageName}/`,
     ]);
 
     return output.split("\n");

--- a/src/server/comands/games/downloader.ts
+++ b/src/server/comands/games/downloader.ts
@@ -17,33 +17,34 @@ export const extractDirName = "extracted";
 
 const downloadingInfo: Record<string, GameStatusInfo> = {};
 const instanceUniqId = Math.random().toString(36);
-const CANCELLED = -1
+const CANCELLED = -1;
 
 let shouldSend = true;
-setInterval(() => { shouldSend = true; }, 30);
+setInterval(() => {
+  shouldSend = true;
+}, 30);
 
 export const progress = async (info: GameStatusInfo) => {
-  if(info.status !== 'cancelling' && cancelRequests[info.id]) {
-    info = { id: info.id, status: 'cancelling' };
+  if (info.status !== "cancelling" && cancelRequests[info.id]) {
+    info = { id: info.id, status: "cancelling" };
   }
   downloadingInfo[info.id] = info;
-  if(shouldSend || info.status !==  'downloading') {
+  if (shouldSend || info.status !== "downloading") {
     shouldSend = false;
-    downloadProgress(info);    
+    downloadProgress(info);
   }
-}
+};
 
 const cancelRequests: { [id: string]: () => void } = {};
 
 export default class Downloader extends RunSystemCommand {
-
   public download(url: string): Promise<string> {
     log.info(`Downloading with https: ${url}`);
     return new Promise((resolve, reject) => {
-      https.get(url, (response) => {
+      https.get(url, response => {
         let data = "";
 
-        response.on("data", (chunk) => {
+        response.on("data", chunk => {
           data += chunk;
         });
 
@@ -55,7 +56,7 @@ export default class Downloader extends RunSystemCommand {
           }
         });
 
-        response.on("error", (error) => {
+        response.on("error", error => {
           reject(error);
         });
       });
@@ -67,7 +68,11 @@ export default class Downloader extends RunSystemCommand {
     fs.rmSync(downloadDirectory, { recursive: true });
   }
 
-  public async downloadFile(fileName: string, baseUrl: string, finalPath: string): Promise<boolean> {
+  public async downloadFile(
+    fileName: string,
+    baseUrl: string,
+    finalPath: string
+  ): Promise<boolean> {
     const tempPath = `${finalPath}`;
 
     if (fs.existsSync(finalPath)) {
@@ -83,13 +88,13 @@ export default class Downloader extends RunSystemCommand {
       accept: "*/*",
     };
     log.info(`Downloading ${url} to ${finalPath}`);
-    
+
     return new Promise((resolve, reject) => {
       const client = http2.connect(url.origin);
       const req = client.request(headers);
       const fileStream = fs.createWriteStream(tempPath);
 
-      req.on("response", (headers) => {
+      req.on("response", headers => {
         if (headers[":status"] !== 200) {
           fileStream.close();
           fs.unlinkSync(finalPath); // Remove the corrupted file
@@ -104,7 +109,7 @@ export default class Downloader extends RunSystemCommand {
           return;
         }
 
-        req.on("data", (chunk) => {
+        req.on("data", chunk => {
           fileStream.write(chunk);
         });
 
@@ -117,7 +122,7 @@ export default class Downloader extends RunSystemCommand {
         });
       });
 
-      req.on("error", (err) => {
+      req.on("error", err => {
         fileStream.close();
         fs.unlinkSync(finalPath); // Remove the corrupted file
         reject(err);
@@ -128,7 +133,11 @@ export default class Downloader extends RunSystemCommand {
     });
   }
 
-  private async getBodyWithHttp2(url: URL, stream?: WriteStream, progress?: (addSize: number) => boolean): Promise<string|boolean> {
+  private async getBodyWithHttp2(
+    url: URL,
+    stream?: WriteStream,
+    progress?: (addSize: number) => boolean
+  ): Promise<string | boolean> {
     log.info(`Downloading: ${url}`);
     const client = http2.connect(url.origin);
     const headers: Record<string, string> = {
@@ -142,19 +151,19 @@ export default class Downloader extends RunSystemCommand {
     let body = stream ? false : "";
     let canceled = false;
     await new Promise((resolve, reject) => {
-      req.on("response", (headers) => {
+      req.on("response", headers => {
         if (headers[":status"] !== 200) {
           reject(`HTTP/2 Error: ${headers[":status"]} ${url}`);
           req.close();
           return;
         }
-        req.on("data", (chunk) => {
-          if(stream) {
+        req.on("data", chunk => {
+          if (stream) {
             stream.write(chunk);
           } else {
             body += chunk;
           }
-          if(progress?.(chunk.length) === false) {
+          if (progress?.(chunk.length) === false) {
             canceled = true;
             req.close();
             client.close();
@@ -162,12 +171,12 @@ export default class Downloader extends RunSystemCommand {
           }
         });
         req.on("end", () => {
-          if(stream) {
+          if (stream) {
             body = true;
             stream.close();
           }
           client.close();
-          if(canceled) {
+          if (canceled) {
             log.debug(`Download on end, canceled: ${url}`);
             reject("Download canceled " + url);
           } else {
@@ -175,13 +184,13 @@ export default class Downloader extends RunSystemCommand {
           }
         });
       });
-      req.on("error", (err) => {
-        if(canceled) {
+      req.on("error", err => {
+        if (canceled) {
           log.debug(`Download on error, canceled: ${url}`);
         }
         reject("Download error " + url + " " + err);
         client.close();
-        if(stream) {
+        if (stream) {
           stream.close();
         }
       });
@@ -191,7 +200,7 @@ export default class Downloader extends RunSystemCommand {
   }
 
   private initDownloadFileLock(downloadPath: string) {
-    fs.readdirSync(downloadPath).forEach((file) => {
+    fs.readdirSync(downloadPath).forEach(file => {
       const filePath = path.join(downloadPath, file);
       const finishedPath = filePath + ".finished";
       if (file.endsWith("finished") || fs.existsSync(finishedPath)) {
@@ -210,7 +219,7 @@ export default class Downloader extends RunSystemCommand {
     return fs.existsSync(path.join(downloadPath, "finished"));
   }
 
-  private prepareDownloadIfNeeded(id: string): string|boolean {
+  private prepareDownloadIfNeeded(id: string): string | boolean {
     const downloadDirectory = path.join(settingsManager.getDownloadsDir(), id);
     if (!fs.existsSync(downloadDirectory)) {
       fs.mkdirSync(downloadDirectory, { recursive: true });
@@ -230,14 +239,14 @@ export default class Downloader extends RunSystemCommand {
   }
 
   private isCanceled(id: string): boolean {
-    if(cancelRequests[id]) {
+    if (cancelRequests[id]) {
       return true;
     }
     return false;
   }
 
   private cancelIfRequested(id: string): boolean {
-    if(cancelRequests[id]) {
+    if (cancelRequests[id]) {
       log.debug(`Canceling previous download: ${id}`);
       cancelRequests[id]();
       return true;
@@ -245,38 +254,43 @@ export default class Downloader extends RunSystemCommand {
     return false;
   }
 
-  public async downloadDir(baseUrl: string, id: string, vrpPublicData: VprPublicData|null): Promise<GameStatusInfo|null> {
+  public async downloadDir(
+    baseUrl: string,
+    id: string,
+    vrpPublicData: VprPublicData | null
+  ): Promise<GameStatusInfo | null> {
     const prepareResult = this.prepareDownloadIfNeeded(id);
-    const url = new URL(id + '/', baseUrl);
+    const url = new URL(id + "/", baseUrl);
     let progressInfo: GameStatusInfo = {
-      id, url: url.toString(),
+      id,
+      url: url.toString(),
       status: "downloading",
       speed: "loading...",
       bytesReceived: 0,
       bytesTotal: 0,
       percent: 0,
       files: [],
-    }
+    };
 
-    if(prepareResult === true) {
+    if (prepareResult === true) {
       progressInfo = { id, status: "downloaded" };
       progress(progressInfo);
       return progressInfo;
     }
     const downloadDirectory = prepareResult as string;
-    
+
     progress(progressInfo);
-    const {files, totalSize} = await this.getGameDownloadFiles(url);
+    const { files, totalSize } = await this.getGameDownloadFiles(url);
     if (files.length === 0) {
       log.error(`Downloading Error: No files found: ${url}`);
       return null;
     }
-    
+
     progressInfo.bytesTotal = totalSize;
     progressInfo.files = files;
     progress(progressInfo);
 
-    if(this.cancelIfRequested(id)) {
+    if (this.cancelIfRequested(id)) {
       return null;
     }
 
@@ -284,27 +298,27 @@ export default class Downloader extends RunSystemCommand {
     try {
       batchResult = await this.batchDownloadFiles(id, url, downloadDirectory, files, progressInfo);
     } catch (err: any) {
-      progressInfo = { id, status: 'error', message: err.message };
+      progressInfo = { id, status: "error", message: err.message };
 
       progressInfo.status = "error";
       progressInfo.message = err.message;
       return null;
     }
 
-    if(this.cancelIfRequested(id)) {
+    if (this.cancelIfRequested(id)) {
       return null;
     }
-    if(batchResult === false) {
-      progressInfo = { id, status: 'error', message: 'Unknown error, see logs' };
+    if (batchResult === false) {
+      progressInfo = { id, status: "error", message: "Unknown error, see logs" };
       progress(progressInfo);
       return null;
     }
 
-    progressInfo = { id, status: 'unzipping' };
+    progressInfo = { id, status: "unzipping" };
     progress(progressInfo);
     await this.unZipDownloadedFiles(id, downloadDirectory, vrpPublicData?.password);
 
-    progressInfo = { id, status: 'downloaded' };
+    progressInfo = { id, status: "downloaded" };
     progress(progressInfo);
 
     fs.writeFileSync(path.join(downloadDirectory, "finished"), new Date().toISOString());
@@ -319,11 +333,14 @@ export default class Downloader extends RunSystemCommand {
       "-o" + downloadDirectory,
       password ? "-p" + password : "",
       path.join(downloadDirectory, id + ".7z.001"),
-    ])
+    ]);
     fs.readdirSync(downloadDirectory)
       .filter(item => fs.statSync(path.join(downloadDirectory, item)).isDirectory())
       .forEach(dir => {
-        fs.renameSync(path.join(downloadDirectory, dir), path.join(downloadDirectory, extractDirName));
+        fs.renameSync(
+          path.join(downloadDirectory, dir),
+          path.join(downloadDirectory, extractDirName)
+        );
       });
 
     fs.readdirSync(downloadDirectory)
@@ -332,21 +349,23 @@ export default class Downloader extends RunSystemCommand {
         fs.unlinkSync(path.join(downloadDirectory, file));
       });
   }
-  
+
   private batchDownloadFiles(
-    id: string, url: URL, downloadDirectory: string,
-    files: DownloadProgress[], progressInfo: GameStatusInfo
+    id: string,
+    url: URL,
+    downloadDirectory: string,
+    files: DownloadProgress[],
+    progressInfo: GameStatusInfo
   ): Promise<boolean> {
-    if(progressInfo.status !== 'downloading')
-      return Promise.resolve(false);
+    if (progressInfo.status !== "downloading") return Promise.resolve(false);
 
     let resolvePromise: (result: boolean) => void;
-    const finalPromise = new Promise<boolean>((resolve) => { 
-      resolvePromise = resolve; 
+    const finalPromise = new Promise<boolean>(resolve => {
+      resolvePromise = resolve;
     });
 
     const queeeMaxSimultaneous = 5;
-    let downloadSpeed = 0; 
+    let downloadSpeed = 0;
     let downloadingNow = 0;
     let currentIndex = 0;
     let success = true;
@@ -358,7 +377,10 @@ export default class Downloader extends RunSystemCommand {
 
     const downloadNext = async () => {
       if (currentIndex >= files.length) {
-        const isFinished = files.reduce((acc, file) => acc && (file?.percent === 100 || file?.percent === CANCELLED), true);
+        const isFinished = files.reduce(
+          (acc, file) => acc && (file?.percent === 100 || file?.percent === CANCELLED),
+          true
+        );
         if (isFinished) {
           resolvePromise(success);
         }
@@ -367,90 +389,97 @@ export default class Downloader extends RunSystemCommand {
       while (downloadingNow < queeeMaxSimultaneous && currentIndex < files.length) {
         downloadingNow++;
         downloadOne(files[currentIndex])
-          .then((result) => { success = success && result; })
+          .then(result => {
+            success = success && result;
+          })
           .finally(() => {
             downloadingNow--;
             log.debug(`Handling next ${currentIndex}/${files.length}`);
             downloadNext();
-          })
+          });
         currentIndex++;
       }
     };
 
-    const downloadOne = async (file: DownloadProgress) => new Promise<boolean>((resolve) => {
-      if (this.isCanceled(id)) {
-        file.percent = CANCELLED;
-        resolve(false);
-        return false;
-      }
-
-      const { url: name} = file;
-      const fileUrl = new URL(name, url);
-      
-      const filePath = path.join(downloadDirectory, name);
-      const finishedPath = filePath + ".finished";
-
-      const finishProgress = () => {
-        file.bytesReceived = file.bytesTotal;
-        file.percent = 100;
-        progress(progressInfo);
-      }
-
-      if (fs.existsSync(finishedPath)) {
-        log.info(`File already exists: ${name}`);
-        progressInfo.bytesReceived! += file.bytesTotal;
-        progressInfo.percent = progressInfo.bytesReceived! / progressInfo.bytesTotal! * 100;
-        finishProgress();
-        resolve(true);
-        return;
-      }
-
-      log.debug(`Downloading ${currentIndex}/${files.length}: ${file.url}`);
-      const fileStream = fs.createWriteStream(filePath);
-      this.getBodyWithHttp2(fileUrl, fileStream, (addSize) => {
-        downloadSpeed += addSize;
-        progressInfo.bytesReceived! += addSize;
-        progressInfo.percent = progressInfo.bytesReceived! / progressInfo.bytesTotal! * 100;
-        file.bytesReceived += addSize;
-        file.percent = file.bytesReceived / file.bytesTotal * 100;
+    const downloadOne = async (file: DownloadProgress) =>
+      new Promise<boolean>(resolve => {
         if (this.isCanceled(id)) {
           file.percent = CANCELLED;
+          resolve(false);
           return false;
         }
-        progress(progressInfo);
-        return true;
-      }).then(() => {
-        fs.writeFileSync(finishedPath, new Date().toISOString());
-        finishProgress();
-        resolve(true);
-      }).catch((err) => {
-        log.error(`Download Error: ${name}`, err);
-        resolve(false);
+
+        const { url: name } = file;
+        const fileUrl = new URL(name, url);
+
+        const filePath = path.join(downloadDirectory, name);
+        const finishedPath = filePath + ".finished";
+
+        const finishProgress = () => {
+          file.bytesReceived = file.bytesTotal;
+          file.percent = 100;
+          progress(progressInfo);
+        };
+
+        if (fs.existsSync(finishedPath)) {
+          log.info(`File already exists: ${name}`);
+          progressInfo.bytesReceived += file.bytesTotal;
+          progressInfo.percent = (progressInfo.bytesReceived / progressInfo.bytesTotal) * 100;
+          finishProgress();
+          resolve(true);
+          return;
+        }
+
+        log.debug(`Downloading ${currentIndex}/${files.length}: ${file.url}`);
+        const fileStream = fs.createWriteStream(filePath);
+        this.getBodyWithHttp2(fileUrl, fileStream, addSize => {
+          downloadSpeed += addSize;
+          progressInfo.bytesReceived += addSize;
+          progressInfo.percent = (progressInfo.bytesReceived / progressInfo.bytesTotal) * 100;
+          file.bytesReceived += addSize;
+          file.percent = (file.bytesReceived / file.bytesTotal) * 100;
+          if (this.isCanceled(id)) {
+            file.percent = CANCELLED;
+            return false;
+          }
+          progress(progressInfo);
+          return true;
+        })
+          .then(() => {
+            fs.writeFileSync(finishedPath, new Date().toISOString());
+            finishProgress();
+            resolve(true);
+          })
+          .catch(err => {
+            log.error(`Download Error: ${name}`, err);
+            resolve(false);
+          });
       });
-    });
 
     downloadNext();
     return finalPromise.finally(() => clearInterval(interval));
   }
 
   private async getGameDownloadFiles(url: URL): Promise<{
-    files: DownloadProgress[],
-    totalSize: number
+    files: DownloadProgress[];
+    totalSize: number;
   }> {
-    const listBody = await this.getBodyWithHttp2(url) as string;
+    const listBody = (await this.getBodyWithHttp2(url)) as string;
     const preTagMatch = listBody.match(/<pre>([\s\S]*?)<\/pre>/);
     let lines: string[] = [];
     if (!preTagMatch) {
       log.error(`Downloading Error: No pre tag found: ${url}`);
     } else {
       const preText = preTagMatch[1];
-      lines = preText.split('\n');  
+      lines = preText.split("\n");
     }
 
     let totalSize = 0;
     const files: DownloadProgress[] = [];
     for (const line of lines) {
-      const match = line.match(/<a href="([^"]+)">[^<]+<\/a>\s+(\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2})\s+(\d+)/);
+      const match = line.match(
+        /<a href="([^"]+)">[^<]+<\/a>\s+(\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2})\s+(\d+)/
+      );
       if (match) {
         const name = match[1];
         const bytesTotal = parseInt(match[3], 10);
@@ -464,22 +493,22 @@ export default class Downloader extends RunSystemCommand {
       }
     }
 
-    return {files, totalSize};
+    return { files, totalSize };
   }
 
   public async cancel(id: string) {
     const cancelRequest = cancelRequests[id];
-    progress({ id, status: 'cancelling' });
-    return new Promise<void>((resolve) => {
+    progress({ id, status: "cancelling" });
+    return new Promise<void>(resolve => {
       cancelRequests[id] = () => {
         if (cancelRequest) {
           cancelRequest();
         }
         log.debug(`Canceled download: ${id}`);
         delete cancelRequests[id];
-        progress({ id, status: 'none' });
+        progress({ id, status: "none" });
         resolve();
-      }
+      };
     });
   }
 }

--- a/src/server/comands/games/images.ts
+++ b/src/server/comands/games/images.ts
@@ -6,7 +6,7 @@ import { downloadDir, resourcesDir } from "@server/dirs";
 export const getImagePath = (packageName: string) => {
   let filePath = join(downloadDir, ".meta", "thumbnails", packageName + ".jpg");
   if (!existsSync(filePath)) {
-    filePath = join(resourcesDir, 'assets/images/matrix.png');
+    filePath = join(resourcesDir, "assets/images/matrix.png");
   }
   return filePath;
-}
+};

--- a/src/server/comands/games/index.ts
+++ b/src/server/comands/games/index.ts
@@ -3,80 +3,86 @@ import GamesManager from "./manager";
 
 export type GamesCommandPayload = GamesActionList | GamesActionWithId | GameActionInstall;
 export type GamesCommandOutput = Game[] | string[] | string | null | void;
-export type GamesCommandName = 'games';
+export type GamesCommandName = "games";
 export type GamesCommand = Command<GamesCommandPayload, Game[], GamesCommandName>;
-export type GamesCommandEvent = CommandEvent<GamesCommandPayload, GamesCommandName>
+export type GamesCommandEvent = CommandEvent<GamesCommandPayload, GamesCommandName>;
 export type Game = {
   id: string;
   category: string;
   name: string;
-  normalName?: string
+  normalName?: string;
   magnetUri: string;
   size: number;
   packageName?: string;
   version?: number;
   lastUpdated?: string;
   completionOn: number;
-}
+};
 
 export type GamesActionList = {
-  action: 'list' | 'listDownloaded';
-}
+  action: "list" | "listDownloaded";
+};
 
 export type GamesActionWithId = {
-  action: 'download' | 'uninstall' | 'removeDownload' | 'cancel' | 'listObbFiles' | 'getLocalFiles';
+  action: "download" | "uninstall" | "removeDownload" | "cancel" | "listObbFiles" | "getLocalFiles";
   id: string;
-}
+};
 
 export type GameActionInstall = {
-  action: 'install';
+  action: "install";
   id: string;
   justMissing?: boolean;
-}
+};
 
 export type DownloadProgress = {
   url: string;
   bytesReceived: number;
   bytesTotal: number;
   percent: number;
-}
+};
 
-export type GameStatusInfo = ({
-  status: 'downloaded' | 'unzipping' | 'installed' | 'none' | 'cancelling';
-} | {
-  status: 'error';
-  message: string;
-} | ({
-  status: 'downloading',
-  speed: string;
-  files: DownloadProgress[];
-} & DownloadProgress) | {
-  status: 'installing',
-  installingFile: string;
-} | {
-  status: 'pushing app data',
-  totalFiles: number;
-  file: {
-    index: number;
-    name: string;
-  }
-}) & { id: string; }
+export type GameStatusInfo = (
+  | {
+      status: "downloaded" | "unzipping" | "installed" | "none" | "cancelling";
+    }
+  | {
+      status: "error";
+      message: string;
+    }
+  | ({
+      status: "downloading";
+      speed: string;
+      files: DownloadProgress[];
+    } & DownloadProgress)
+  | {
+      status: "installing";
+      installingFile: string;
+    }
+  | {
+      status: "pushing app data";
+      totalFiles: number;
+      file: {
+        index: number;
+        name: string;
+      };
+    }
+) & { id: string };
 
-export type GameStatusType = GameStatusInfo['status'];
+export type GameStatusType = GameStatusInfo["status"];
 
 export default {
-  type: 'games',
+  type: "games",
   receiver: async function (payload: GamesCommandPayload): Promise<GamesCommandOutput> {
-    if (payload.action === 'list') {
+    if (payload.action === "list") {
       await GamesManager.update();
       return GamesManager.listGames();
-    } else if (payload.action === 'listDownloaded') {
+    } else if (payload.action === "listDownloaded") {
       return GamesManager.getDownloadedGames();
-    } else if (payload.action === 'install') {
+    } else if (payload.action === "install") {
       return GamesManager.install(payload.id, payload.justMissing);
     }
 
     payload = payload as GamesActionWithId;
     return GamesManager[payload.action](payload.id);
-  }
+  },
 } as GamesCommand;

--- a/src/server/comands/games/manager.ts
+++ b/src/server/comands/games/manager.ts
@@ -1,14 +1,14 @@
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
 import type { Game } from ".";
 
-import adbManager from '@comands/adb/manager';
-import settingsManager from '@comands/settings/manager';
-import log from '@server/log';
+import adbManager from "@comands/adb/manager";
+import settingsManager from "@comands/settings/manager";
+import log from "@server/log";
 import HttpDownloader, { extractDirName, progress } from "./downloader";
-import vrpManager from './vrpManager';
-import vrpPublic from './vrpPublic';
+import vrpManager from "./vrpManager";
+import vrpPublic from "./vrpPublic";
 
 interface WebGame {
   name?: string;
@@ -45,7 +45,7 @@ class GameManager {
     if (this.lastPromise) {
       return this.lastPromise;
     }
-    this.lastPromise = this.updateTask().finally(() => this.lastPromise = null);
+    this.lastPromise = this.updateTask().finally(() => (this.lastPromise = null));
     return this.lastPromise;
   }
 
@@ -77,7 +77,7 @@ class GameManager {
           normalName: existingGame?.name,
           lastUpdated: existingGame?.lastUpdated,
           version: existingGame?.version,
-        } as Game
+        } as Game;
       });
 
       return true;
@@ -97,9 +97,9 @@ class GameManager {
   }
 
   private getGameId(releaseName: string): string {
-    const hash = crypto.createHash('md5');
+    const hash = crypto.createHash("md5");
     hash.update(releaseName + "\n");
-    return hash.digest('hex');
+    return hash.digest("hex");
   }
 
   public async download(id: string) {
@@ -109,7 +109,7 @@ class GameManager {
       return;
     }
 
-    this.downloader.downloadDir(vrpInfo.baseUri, id, await vrpPublic)
+    this.downloader.downloadDir(vrpInfo.baseUri, id, await vrpPublic);
   }
 
   public async removeDownload(id: string) {
@@ -117,8 +117,8 @@ class GameManager {
     this.getDownloadedGames();
   }
 
-  public async uninstall(id: string): Promise<string|null> {
-    const game = this.games.find((g) => g.id === id);
+  public async uninstall(id: string): Promise<string | null> {
+    const game = this.games.find(g => g.id === id);
     if (!game || !game.packageName) {
       return "Game not found:" + id;
     }
@@ -127,8 +127,8 @@ class GameManager {
     return null;
   }
 
-  private async getDownloadedGameInfo(id: string): Promise<DownloadedGameFilesInfo|null> {
-    const game = this.games.find((g) => g.id === id);
+  private async getDownloadedGameInfo(id: string): Promise<DownloadedGameFilesInfo | null> {
+    const game = this.games.find(g => g.id === id);
     if (!game || !game.packageName) {
       return null;
     }
@@ -142,11 +142,13 @@ class GameManager {
       dataDir: fs.existsSync(dataDir) ? dataDir : undefined,
       packageName: game.packageName,
       obbFiles: fs.existsSync(dataDir) ? fs.readdirSync(dataDir) : undefined,
-      apkFile: fs.existsSync(gameDir) ? fs.readdirSync(gameDir).find((file) => file.endsWith(".apk")) || undefined : undefined
-    }
+      apkFile: fs.existsSync(gameDir)
+        ? fs.readdirSync(gameDir).find(file => file.endsWith(".apk")) || undefined
+        : undefined,
+    };
   }
 
-  public async install(id: string, justMissing: boolean = false): Promise<string|null> {
+  public async install(id: string, justMissing: boolean = false): Promise<string | null> {
     const gameInfo = await this.getDownloadedGameInfo(id);
     if (!gameInfo) {
       return "Game or package name not found:" + id;
@@ -159,34 +161,39 @@ class GameManager {
     }
 
     let installedObbFiles: string[] = [];
-    if(justMissing) {
+    if (justMissing) {
       installedObbFiles = await adbManager.listObbFiles(packageName);
     }
 
     try {
-      progress({ id , status: 'installing', installingFile: apkFile });
-      if(!justMissing) {
+      progress({ id, status: "installing", installingFile: apkFile });
+      if (!justMissing) {
         await adbManager.install(path.join(gameDir, apkFile));
       }
 
       if (obbFiles && dataDir) {
         await adbManager.createObbDir(packageName || "");
 
-        for(let index = 0; index < obbFiles.length; index++) {
+        for (let index = 0; index < obbFiles.length; index++) {
           const name = obbFiles[index];
-          progress({ id , status: 'pushing app data', file: { index, name }, totalFiles: obbFiles.length });
+          progress({
+            id,
+            status: "pushing app data",
+            file: { index, name },
+            totalFiles: obbFiles.length,
+          });
 
-          if(justMissing && installedObbFiles.includes(name)) {
+          if (justMissing && installedObbFiles.includes(name)) {
             continue;
           }
           await adbManager.pushObbFile(path.join(dataDir, name), packageName || "");
         }
       }
     } catch (err: any) {
-      progress({ id , status: 'error', message: err });
+      progress({ id, status: "error", message: err });
       return "Failed to install game: " + err;
     }
-    progress({ id , status: 'installed'});
+    progress({ id, status: "installed" });
     return null;
   }
 
@@ -195,7 +202,7 @@ class GameManager {
   }
 
   public async listObbFiles(id: string): Promise<string[]> {
-    const game = this.games.find((g) => g.id === id);
+    const game = this.games.find(g => g.id === id);
     if (!game || !game.packageName) {
       return [];
     }

--- a/src/server/comands/games/vrpManager.ts
+++ b/src/server/comands/games/vrpManager.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { extractFull } from 'node-7z';
+import { extractFull } from "node-7z";
 import { join } from "path";
 
 import settingsManager from "@comands/settings/manager";
@@ -18,10 +18,12 @@ export interface GameInfo {
   size: string;
 }
 
-type CachedGameInfo  = {
-  lastDownloaded: string;
-  games: GameInfo[];
-} | GameInfo[];
+type CachedGameInfo =
+  | {
+      lastDownloaded: string;
+      games: GameInfo[];
+    }
+  | GameInfo[];
 
 const metaFileName = "meta.7z";
 const metaFilePath = join(downloadDir, metaFileName);
@@ -69,7 +71,7 @@ export class VprManager extends RunSystemCommand {
       }
 
       this.games.clear();
-      json.games.forEach((game) => {
+      json.games.forEach(game => {
         this.games.set(game.releaseName, game);
       });
 
@@ -110,11 +112,15 @@ export class VprManager extends RunSystemCommand {
     const vrpInfo = await vrpPublic;
     if (!vrpInfo) {
       log.error("Failed to get VRP info");
-      return false
+      return false;
     }
 
     try {
-      const downloaded = await downloader.downloadFile(metaFileName, vrpInfo?.baseUri, metaFilePath);
+      const downloaded = await downloader.downloadFile(
+        metaFileName,
+        vrpInfo?.baseUri,
+        metaFilePath
+      );
 
       if (!downloaded) {
         log.error("Failed to download metadata");
@@ -122,18 +128,18 @@ export class VprManager extends RunSystemCommand {
       }
 
       const SevenZipPath = await this.getSevenZipPath();
-      await (new Promise((resolve, reject) => {
+      await new Promise((resolve, reject) => {
         log.info("Extracting metadata...", SevenZipPath);
         const seven = extractFull(metaFilePath, downloadDir, {
           $bin: SevenZipPath,
-          password: vrpInfo.password
-        })
-        seven.on('end', function () {
+          password: vrpInfo.password,
+        });
+        seven.on("end", function () {
           resolve(null);
-        })
+        });
 
-        seven.on('error', reject)
-      }));
+        seven.on("error", reject);
+      });
 
       this.parseMetadata();
       this.loadGamesInfo();
@@ -195,10 +201,10 @@ export class VprManager extends RunSystemCommand {
   }
 
   public getDownloadedGames(): string[] {
-    return fs.readdirSync(settingsManager.getDownloadsDir()).filter((file) => 
-      fs.existsSync(join(settingsManager.getDownloadsDir(), file, "finished"))
-    );
+    return fs
+      .readdirSync(settingsManager.getDownloadsDir())
+      .filter(file => fs.existsSync(join(settingsManager.getDownloadsDir(), file, "finished")));
   }
 }
 
-export default (new VprManager());
+export default new VprManager();

--- a/src/server/comands/games/vrpPublic.ts
+++ b/src/server/comands/games/vrpPublic.ts
@@ -1,9 +1,9 @@
-import log from '@server/log';
+import log from "@server/log";
 import HttpDownloader from "./downloader";
 
 export interface VprPublicData {
-    baseUri: string;
-    password: string;
+  baseUri: string;
+  password: string;
 }
 
 export class VprPublic {
@@ -35,4 +35,4 @@ export class VprPublic {
   }
 }
 
-export default (new VprPublic()).fetchData();
+export default new VprPublic().fetchData();

--- a/src/server/comands/index.ts
+++ b/src/server/comands/index.ts
@@ -15,17 +15,18 @@ const commands: Command<any, any, any>[] = [
 ];
 
 export const executeCommand = async (comandEvent: CommandEvent<any, any>) => {
-  const command = commands.filter((command) => command.type === comandEvent.type)
+  const command = commands.filter(command => command.type === comandEvent.type);
   if (command.length === 1) {
     return await command[0].receiver(comandEvent.payload);
-  } if (command.length > 1) {
+  }
+  if (command.length > 1) {
     log.error(`Multiple commands with the same type: ${comandEvent.type}`, commands);
   } else {
     log.error(`Unknown command type: ${comandEvent.type}`);
   }
   return null;
-}
+};
 
 export const downloadProgress = async (info: GameStatusInfo) => {
   sendInfo(info);
-}
+};

--- a/src/server/comands/settings/devTools.ts
+++ b/src/server/comands/settings/devTools.ts
@@ -1,14 +1,14 @@
 import { Command, CommandEvent } from "@comands/types";
 
-export type DevToolsCommandName = 'devTools'
-export type DevToolsCommand = Command<void, void, DevToolsCommandName>
-export type DevToolsCommandEvent = CommandEvent<void, DevToolsCommandName>
+export type DevToolsCommandName = "devTools";
+export type DevToolsCommand = Command<void, void, DevToolsCommandName>;
+export type DevToolsCommandEvent = CommandEvent<void, DevToolsCommandName>;
 
 export default {
-  type: 'devTools',
+  type: "devTools",
   receiver: function () {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { BrowserWindow } = require('electron');
+    const { BrowserWindow } = require("electron");
 
     const focusedWindow = BrowserWindow.getFocusedWindow();
     if (focusedWindow) {
@@ -18,5 +18,5 @@ export default {
         focusedWindow.webContents.openDevTools();
       }
     }
-  }
+  },
 } as DevToolsCommand;

--- a/src/server/comands/settings/index.ts
+++ b/src/server/comands/settings/index.ts
@@ -3,16 +3,16 @@ import settingsManager from "./manager";
 
 export type SettingsCommandPayload = SettinsActions;
 export type SettingsCommandOutput = Settings | SystemHelth;
-export type SettingsCommandName = 'settings';
+export type SettingsCommandName = "settings";
 export type SettingsCommand = Command<SettingsCommandPayload, Settings, SettingsCommandName>;
-export type SettingsCommandEvent = CommandEvent<SettingsCommandPayload, SettingsCommandName>
+export type SettingsCommandEvent = CommandEvent<SettingsCommandPayload, SettingsCommandName>;
 export type SettingsCommandOutputs = {
   settings: Settings;
   systemHelth: SystemHelth;
-}
+};
 export type Settings = {
   downloadsDir?: string;
-}
+};
 export type SystemHelth = {
   appVersion: string;
   electronVersion: string;
@@ -21,20 +21,20 @@ export type SystemHelth = {
   unzip: string;
   sevenZip: string;
   java: string;
-}
+};
 
 export type SettinsActions = {
-  action: 'list' | 'setDownloadsDir' | 'getSystemHelth';
-}
+  action: "list" | "setDownloadsDir" | "getSystemHelth";
+};
 
 export default {
-  type: 'settings',
+  type: "settings",
   receiver: async function (payload: SettingsCommandPayload): Promise<SettingsCommandOutput> {
-    if (payload.action === 'getSystemHelth') {
+    if (payload.action === "getSystemHelth") {
       return settingsManager.getSystemHelth();
-    } else if (payload.action === 'setDownloadsDir') {
+    } else if (payload.action === "setDownloadsDir") {
       await settingsManager.setDownloadsDir();
     }
     return settingsManager.get();
-  }
+  },
 } as SettingsCommand;

--- a/src/server/comands/settings/manager.ts
+++ b/src/server/comands/settings/manager.ts
@@ -6,15 +6,17 @@ import log from "@server/log";
 import SystemProcess from "@server/systemProcess";
 import type { Settings, SystemHelth } from ".";
 
-export const appVersion = JSON.parse(fs.readFileSync(path.join(buildRoot, "package.json"), "utf-8")).version;
+export const appVersion = JSON.parse(
+  fs.readFileSync(path.join(buildRoot, "package.json"), "utf-8")
+).version;
 
 const settingsPath = path.join(appDataDir, "settings.json");
-const { showOpenDialog } = (function() {
+const { showOpenDialog } = (function () {
   if (process.versions.electron) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return { showOpenDialog: require("electron").dialog.showOpenDialog};
+    return { showOpenDialog: require("electron").dialog.showOpenDialog };
   }
-  return { showOpenDialog: async () => ({canceled: true, filePaths: []})};
+  return { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) };
 })();
 
 class SettingsManager extends SystemProcess {
@@ -22,7 +24,9 @@ class SettingsManager extends SystemProcess {
 
   constructor() {
     super();
-    this.settings = fs.existsSync(settingsPath) ? JSON.parse(fs.readFileSync(settingsPath, "utf-8")) : {};
+    this.settings = fs.existsSync(settingsPath)
+      ? JSON.parse(fs.readFileSync(settingsPath, "utf-8"))
+      : {};
     this.createDownloadsDir();
   }
   private async createDownloadsDir() {
@@ -36,7 +40,7 @@ class SettingsManager extends SystemProcess {
       title: "Select downloads dir",
       properties: ["openDirectory"],
     });
-    
+
     if (!result.canceled && result.filePaths.length > 0) {
       const selectedPath = result.filePaths[0];
       this.settings.downloadsDir = selectedPath;
@@ -49,15 +53,12 @@ class SettingsManager extends SystemProcess {
   public get(): Settings {
     return {
       ...this.settings,
-      ...(process.env.ROOKIE_DOWNLOADS_DIR
-        ? {downloadsDir: this.getDownloadsDir()}
-        : {}
-      ),
+      ...(process.env.ROOKIE_DOWNLOADS_DIR ? { downloadsDir: this.getDownloadsDir() } : {}),
     };
   }
 
   public getDownloadsDir(): string {
-    if(process.env.ROOKIE_DOWNLOADS_DIR && fs.existsSync(process.env.ROOKIE_DOWNLOADS_DIR)) {
+    if (process.env.ROOKIE_DOWNLOADS_DIR && fs.existsSync(process.env.ROOKIE_DOWNLOADS_DIR)) {
       return process.env.ROOKIE_DOWNLOADS_DIR;
     }
     if (this.settings.downloadsDir && fs.existsSync(this.settings.downloadsDir)) {
@@ -66,16 +67,20 @@ class SettingsManager extends SystemProcess {
     return gamesDir;
   }
 
-  private async getCommandInfo(path: string|null, name: string, lines: number, arg: string = "-h"): Promise<string> {
+  private async getCommandInfo(
+    path: string | null,
+    name: string,
+    lines: number,
+    arg: string = "-h"
+  ): Promise<string> {
     if (!path) {
       return "Not found, Please install " + name;
     }
     const { stdout } = await this.runCommand(path, [arg]);
-    return path + "\n" +
-      stdout.split("\n").slice(0, lines).join("\n");
+    return path + "\n" + stdout.split("\n").slice(0, lines).join("\n");
   }
 
-  private static systemHelthCache: Promise<SystemHelth>|null = null;
+  private static systemHelthCache: Promise<SystemHelth> | null = null;
 
   public async getSystemHelth(): Promise<SystemHelth> {
     if (!SettingsManager.systemHelthCache) {
@@ -87,10 +92,12 @@ class SettingsManager extends SystemProcess {
   private async getSystemHelthInternal(): Promise<SystemHelth> {
     const asyncResults = {
       adb: this.getCommandInfo(this.getAdbPath(), "adb", 2, "version"),
-      unzip: this.getCommanPath('unzip').then(path => this.getCommandInfo(path, "unzip", 1)),
+      unzip: this.getCommanPath("unzip").then(path => this.getCommandInfo(path, "unzip", 1)),
       sevenZip: this.getSevenZipPath().then(path => this.getCommandInfo(path, "7zip", 2)),
-      java: this.getCommanPath('java').then(path => this.getCommandInfo(path, "java", 3, "--version")),
-    }
+      java: this.getCommanPath("java").then(path =>
+        this.getCommandInfo(path, "java", 3, "--version")
+      ),
+    };
 
     return {
       appVersion,

--- a/src/server/comands/types.ts
+++ b/src/server/comands/types.ts
@@ -1,16 +1,36 @@
-export type CommandSender = <Name extends string, Input = any, Output = any>(command: CommandEvent<Input, Name>) => Promise<Output>;
-export type CommandReceiver<Input, Output, Type> = (payload?: Input, name?: Type) => Promise<Output>;
-export type Command<Input, Output, Type extends string> = { type: Type; receiver: CommandReceiver<Input, Output, Type>;}
-export type CommandEvent<Input, Name extends string> = { type: Name; payload?: Input; }
+declare global {
+  interface Window {
+    sendCommand: (_command: string, _payload?: unknown) => Promise<unknown>;
+    downloads: {
+      receive: (_callback: (_data: unknown) => void) => void;
+    };
+  }
+}
 
-export const BridgeSendCommandEvent = 'sendCommand';
-export type BridgeSendCommandEventType = 'sendCommand';
+export type CommandSender = <Name extends string, Input = unknown, Output = unknown>(
+  command: CommandEvent<Input, Name>
+) => Promise<Output>;
+export type CommandReceiver<Input, Output, Type> = (
+  payload?: Input,
+  name?: Type
+) => Promise<Output>;
+export type Command<Input, Output, Type extends string> = {
+  type: Type;
+  receiver: CommandReceiver<Input, Output, Type>;
+};
+export type CommandEvent<Input, Name extends string> = {
+  type: Name;
+  payload?: Input;
+};
 
-export * from './adb';
-export * from './adb/androidToolsSetup';
-export * from './games';
-export * from './settings';
-export * from './settings/devTools';
+export const BridgeSendCommandEvent = "sendCommand";
+export type BridgeSendCommandEventType = "sendCommand";
 
-const All = {}
+export * from "./adb";
+export * from "./adb/androidToolsSetup";
+export * from "./games";
+export * from "./settings";
+export * from "./settings/devTools";
+
+const All = {};
 export default All;

--- a/src/server/dirs.ts
+++ b/src/server/dirs.ts
@@ -7,15 +7,15 @@ import log from "./log";
 const platformPaths: Record<string, () => string> = {
   win32: () => join(homedir(), "AppData/Roaming/qrookie-node"),
   darwin: () => join(homedir(), "Library/Application Support/qrookie-node"),
-  linux: () => join(homedir(), ".config/qrookie-node")
+  linux: () => join(homedir(), ".config/qrookie-node"),
 };
 const userDataDir = (platformPaths[process.platform] ?? platformPaths.linux)();
 
 log.info("userDataDir: " + userDataDir);
 
 let foundResourcesDir = __dirname;
-while (!existsSync(join(foundResourcesDir, 'dist'))) {
-  foundResourcesDir = join(foundResourcesDir, '..');
+while (!existsSync(join(foundResourcesDir, "dist"))) {
+  foundResourcesDir = join(foundResourcesDir, "..");
 }
 
 export const resourcesDir = foundResourcesDir;
@@ -23,7 +23,7 @@ export const buildRoot = __dirname;
 export const appDataDir = join(userDataDir, "data");
 export const extractedDir = join(appDataDir, "uncrompressed");
 export const downloadDir = join(appDataDir, "downloads");
-export const gamesDirName = "VrGames"
+export const gamesDirName = "VrGames";
 export const gamesDir = join(downloadDir, gamesDirName);
 
 mkdirSync(extractedDir, { recursive: true });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,6 @@ import { GameStatusInfo } from "@comands/games";
 import log from "./log";
 import { sendInfo as sendInfoNode } from "./main/node";
 
-
 let sendInfoElectron: ((info: GameStatusInfo) => void) | null = null;
 if (process.versions.electron) {
   try {

--- a/src/server/log.ts
+++ b/src/server/log.ts
@@ -7,14 +7,15 @@ const log = {
   userInfo: (...args: any[]) => console.log("\x1b[33m", ...args, "\x1b[0m"),
   debug: (...args: any[]) => shouldDebug && console.log("\x1b[35m", ...args, "\x1b[0m"),
   command: (command: string, args: string[], stdout: string, stderr: string) => {
-    if(!shouldDebug)
-      return;
+    if (!shouldDebug) return;
     const stdoutLines = stdout.split("\n");
     console.log(
       "\n\x1b[32m<----------------------------------------",
       `\nCommand \x1b[33m'${command} ${args.join(" ")}'\x1b[32m executed\nstdout:\x1b[0m`,
       "\n\x1b[34m" + stdoutLines.slice(0, MAX_LOG_COMMAND_OUTPUT_LINES).join("\n") + "\x1b[0m",
-      stdoutLines.length > 20 ? `\n...and ${stdoutLines.length - MAX_LOG_COMMAND_OUTPUT_LINES} more lines` : "",
+      stdoutLines.length > 20
+        ? `\n...and ${stdoutLines.length - MAX_LOG_COMMAND_OUTPUT_LINES} more lines`
+        : "",
       stderr ? "\n\x1b[31mWith stderr: \n" + stderr + "\x1b[0m" : "",
       "\n\x1b[32m---------------------------------------->\x1b[0m"
     );
@@ -26,21 +27,21 @@ const log = {
       "\n" + error,
       "\n---------------------------------------->\x1b[0m"
     );
-  }
+  },
 };
 
 let shouldDebug = false;
 let shouldWarn = false;
 let shouldInfo = false;
 
-const isVerbose = process.argv.includes("--verbose")
-if(isVerbose || process.argv.includes("--debug")) {
+const isVerbose = process.argv.includes("--verbose");
+if (isVerbose || process.argv.includes("--debug")) {
   shouldDebug = true;
 }
-if(isVerbose || process.argv.includes("--warn")) {
+if (isVerbose || process.argv.includes("--warn")) {
   shouldWarn = true;
 }
-if(isVerbose || process.argv.includes("--info")) {
+if (isVerbose || process.argv.includes("--info")) {
   shouldInfo = true;
 }
 

--- a/src/server/main/electron/bridge.ts
+++ b/src/server/main/electron/bridge.ts
@@ -7,17 +7,20 @@ import { BridgeSendCommandEvent, CommandEvent, GameStatusInfo } from "@server/co
 import { getMainWindow } from ".";
 
 app.whenReady().then(() => {
-  protocol.handle('game-image', (request) => {
+  protocol.handle("game-image", request => {
     const packageName = decodeURIComponent(request.url.replace("game-image://", ""));
-    return net.fetch('file://' + path.normalize(getImagePath(packageName)));
-  })
+    return net.fetch("file://" + path.normalize(getImagePath(packageName)));
+  });
 });
 
 console.log("Bridge is ready");
-ipcMain.handle(BridgeSendCommandEvent, async (event: IpcMainInvokeEvent, comandEvent: CommandEvent<any, any>) => {
-  return executeCommand(comandEvent);
-});
+ipcMain.handle(
+  BridgeSendCommandEvent,
+  async (event: IpcMainInvokeEvent, comandEvent: CommandEvent<any, any>) => {
+    return executeCommand(comandEvent);
+  }
+);
 
 export const sendInfo = async (info: GameStatusInfo) => {
   getMainWindow()?.webContents.send("downloadProgress", info);
-}
+};

--- a/src/server/main/electron/index.ts
+++ b/src/server/main/electron/index.ts
@@ -1,51 +1,51 @@
 import { app, BrowserWindow } from "electron";
 import path from "path";
 
-import './bridge';
+import "./bridge";
 import { setupMenu } from "./menu";
 
 import { resourcesDir } from "@server/dirs";
 
-export function getMainWindow(): BrowserWindow|null {
+export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
 }
 
-let mainWindow: BrowserWindow|null = null;
+let mainWindow: BrowserWindow | null = null;
 
 const createMainWindow = () => {
   const isHeadless = process.argv.includes("--headless");
-  if (isHeadless)
-    return
+  if (isHeadless) return;
 
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 800,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
-    }
+    },
   });
 
-  if (process.env.NODE_ENV === 'development') {
-    mainWindow.loadURL('http://localhost:3000');
+  if (process.env.NODE_ENV === "development") {
+    mainWindow.loadURL("http://localhost:3000");
   } else {
-    mainWindow.loadFile(path.join(resourcesDir, 'dist/react/index.html'));
+    mainWindow.loadFile(path.join(resourcesDir, "dist/react/index.html"));
     setupMenu();
   }
 
-  mainWindow.on('closed', () => { mainWindow = null;});
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
 };
 
-app.on('ready', createMainWindow);
-app.on('activate', () => {
+app.on("ready", createMainWindow);
+app.on("activate", () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createMainWindow();
   }
 });
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
     app.quit();
   }
 });
-

--- a/src/server/main/electron/preload.ts
+++ b/src/server/main/electron/preload.ts
@@ -2,16 +2,16 @@ import { contextBridge, ipcRenderer } from "electron";
 
 import { BridgeSendCommandEventType, CommandSender } from "@comands/types";
 
-export const BridgeSendCommandEvent: BridgeSendCommandEventType = 'sendCommand';
+export const BridgeSendCommandEvent: BridgeSendCommandEventType = "sendCommand";
 
 if (contextBridge) {
   ipcRenderer.setMaxListeners(50);
   contextBridge.exposeInMainWorld(
     BridgeSendCommandEvent,
-    (async (command) => await ipcRenderer.invoke(BridgeSendCommandEvent, command)) as CommandSender
-  )
-  contextBridge.exposeInMainWorld('downloads', {
+    (async command => await ipcRenderer.invoke(BridgeSendCommandEvent, command)) as CommandSender
+  );
+  contextBridge.exposeInMainWorld("downloads", {
     receive: (func: any) => ipcRenderer.on("downloadProgress", (event, ...args) => func(...args)),
     remove: (callback: any) => ipcRenderer.removeListener("downloadProgress", callback),
   });
-} 
+}

--- a/src/server/main/node/index.ts
+++ b/src/server/main/node/index.ts
@@ -4,36 +4,52 @@ import { executeCommand } from "@server/comands";
 import { appVersion } from "@server/comands/settings/manager";
 import { CommandEvent, GameStatusInfo } from "@server/comands/types";
 import log from "@server/log";
-import server from './reactServer';
+import server from "./reactServer";
 
-type BridgeMessage = 
-    { id: string; event: 'command'; data: CommandEvent<any, any>;} |
-    { id: string; event: 'command-response'; error: boolean; data: unknown;} |
-    { event: 'download-progress'; data: GameStatusInfo; }
+type BridgeMessage =
+  | { id: string; event: "command"; data: CommandEvent<any, any> }
+  | { id: string; event: "command-response"; error: boolean; data: unknown }
+  | { event: "download-progress"; data: GameStatusInfo };
 
-if(server.listening) {
+if (server.listening) {
   log.info("WebSocket server is listening");
-  new WebSocketServer({ server }).on("connection", (ws) => {
+  new WebSocketServer({ server }).on("connection", ws => {
     connections.push(ws);
     log.debug("Client connected via WebSocket");
-  
-    ws.on("message", (message) => {
+
+    ws.on("message", message => {
       try {
         const parsedMessage = JSON.parse(message.toString()) as BridgeMessage;
         log.debug(`Received message: ${message.toString()}`);
-  
-        if (parsedMessage.event === 'command') {
-          executeCommand(parsedMessage.data).then((data) => {
-            ws.send(JSON.stringify({ event: "command-response", id: parsedMessage.id, error: false, data }));
-          }).catch((error) => {
-            ws.send(JSON.stringify({ event: "command-response", id: parsedMessage.id, error: true, data: error }));
-          });
+
+        if (parsedMessage.event === "command") {
+          executeCommand(parsedMessage.data)
+            .then(data => {
+              ws.send(
+                JSON.stringify({
+                  event: "command-response",
+                  id: parsedMessage.id,
+                  error: false,
+                  data,
+                })
+              );
+            })
+            .catch(error => {
+              ws.send(
+                JSON.stringify({
+                  event: "command-response",
+                  id: parsedMessage.id,
+                  error: true,
+                  data: error,
+                })
+              );
+            });
         }
       } catch (err) {
         log.error("Error parsing message", err);
       }
     });
-  
+
     ws.on("close", () => {
       log.debug("Client disconnected");
       connections.splice(connections.indexOf(ws), 1);
@@ -44,14 +60,14 @@ if(server.listening) {
 }
 
 export const sendInfo = async (info: GameStatusInfo) => {
-  connections.forEach((ws) => {
+  connections.forEach(ws => {
     ws.send(JSON.stringify({ event: "download-progress", data: info } as BridgeMessage));
   });
-}
+};
 
 const connections: WebSocket[] = [];
 
-if(process.argv.includes("--help") || process.argv.includes("-h")) {
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
   log.userInfo("Version:", appVersion);
   log.userInfo("Usage: ./start [options]");
   log.userInfo();

--- a/src/server/main/node/reactServer.ts
+++ b/src/server/main/node/reactServer.ts
@@ -23,8 +23,9 @@ const server = createServer((req, res) => {
     });
     return;
   }
-        
-  const filePath = req.url === "/" ? join(reactBuildPath, "index.html") : join(reactBuildPath, req.url!);
+
+  const filePath =
+    req.url === "/" ? join(reactBuildPath, "index.html") : join(reactBuildPath, req.url!);
   readFile(filePath, (err, data) => {
     if (err) {
       res.writeHead(404);

--- a/src/server/systemProcess.ts
+++ b/src/server/systemProcess.ts
@@ -9,7 +9,6 @@ import log from "./log";
 const execFileAsync = promisify(execFile);
 
 export default abstract class SystemProcess {
-
   private static adbPath?: string;
 
   constructor() {
@@ -17,24 +16,28 @@ export default abstract class SystemProcess {
       return;
     }
     SystemProcess.adbPath = path.join(platformToolsDir, "adb" + binExt);
-    this.getCommanPath('adb').then((path) => {
-      if (path) {
-        SystemProcess.adbPath = path;
-        log.info("ADB found at:", path);
-        return;
-      }
-      log.warn(`ADB not found, downloading platform-tools. getCommanPath returned: '${path}'`);
-      setupTools();
-    }).catch((err) => {
-      log.error(`ADB not found, downloading platform-tools. getCommanPath returned error: '${err.message}'`);
-      setupTools();
-    });
+    this.getCommanPath("adb")
+      .then(path => {
+        if (path) {
+          SystemProcess.adbPath = path;
+          log.info("ADB found at:", path);
+          return;
+        }
+        log.warn(`ADB not found, downloading platform-tools. getCommanPath returned: '${path}'`);
+        setupTools();
+      })
+      .catch(err => {
+        log.error(
+          `ADB not found, downloading platform-tools. getCommanPath returned error: '${err.message}'`
+        );
+        setupTools();
+      });
   }
 
-  public async getCommanPath(comandName: string): Promise<string|null> {
+  public async getCommanPath(comandName: string): Promise<string | null> {
     try {
       const { stdout } = await execFileAsync("which", [comandName]);
-      const path = (stdout||'').trim();
+      const path = (stdout || "").trim();
       return path !== "" ? path : null;
     } catch (error: any) {
       log.warn("Command error: ", error.message);
@@ -42,7 +45,10 @@ export default abstract class SystemProcess {
     }
   }
 
-  public async runCommand(comandWithPath: string, args: string[]): Promise<{
+  public async runCommand(
+    comandWithPath: string,
+    args: string[]
+  ): Promise<{
     stdout: string;
     stderr: string;
   }> {
@@ -54,16 +60,17 @@ export default abstract class SystemProcess {
       return { stdout, stderr };
     } catch (error: any) {
       log.commandError(comandWithPath, args, error.message);
-      return { stdout: "", stderr: error.message }
+      return { stdout: "", stderr: error.message };
     }
   }
 
   public async getSevenZipPath(): Promise<string> {
-    return await this.getCommanPath('7za') ?? sevenBin.path7za.replace("app.asar", "app.asar.unpacked");
+    return (
+      (await this.getCommanPath("7za")) ?? sevenBin.path7za.replace("app.asar", "app.asar.unpacked")
+    );
   }
 
   public getAdbPath(): string {
     return SystemProcess.adbPath || "error";
   }
-
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src/react/**/*"]
+  "include": ["src/react/**/*", "src/*.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==
 
 "@adobe/css-tools@^4.0.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.1.tgz#2447a230bfe072c1659e6815129c03cf170710e3"
-  integrity sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.2.tgz#c836b1bd81e6d62cd6cdf3ee4948bcdce8ea79c8"
+  integrity sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
@@ -34,35 +34,35 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2", "@babel/code-frame@^7.8.3":
-  version "7.26.2"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
-  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.8.3":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.27.1"
     js-tokens "^4.0.0"
-    picocolors "^1.0.0"
+    picocolors "^1.1.1"
 
-"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.5.tgz#df93ac37f4417854130e21d72c66ff3d4b897fc7"
-  integrity sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.2.tgz#4183f9e642fd84e74e3eea7ffa93a412e3b102c9"
+  integrity sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==
 
 "@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.7.tgz#0439347a183b97534d52811144d763a17f9d2b24"
-  integrity sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.1.tgz#89de51e86bd12246003e3524704c49541b16c3e6"
+  integrity sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/helper-compilation-targets" "^7.26.5"
-    "@babel/helper-module-transforms" "^7.26.0"
-    "@babel/helpers" "^7.26.7"
-    "@babel/parser" "^7.26.7"
-    "@babel/template" "^7.25.9"
-    "@babel/traverse" "^7.26.7"
-    "@babel/types" "^7.26.7"
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helpers" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -70,69 +70,69 @@
     semver "^6.3.1"
 
 "@babel/eslint-parser@^7.16.3":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz#aa669f4d873f9cd617050cf3c40c19cd96307efb"
-  integrity sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.27.1.tgz#e146fb2facef62c6c5d1a6fd07cfd79ee9f7b0f1"
+  integrity sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.1"
 
-"@babel/generator@^7.26.5", "@babel/generator@^7.7.2":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.5.tgz#e44d4ab3176bbcaf78a5725da5f1dc28802a9458"
-  integrity sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==
+"@babel/generator@^7.27.1", "@babel/generator@^7.7.2":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.1.tgz#862d4fad858f7208edd487c28b58144036b76230"
+  integrity sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==
   dependencies:
-    "@babel/parser" "^7.26.5"
-    "@babel/types" "^7.26.5"
+    "@babel/parser" "^7.27.1"
+    "@babel/types" "^7.27.1"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz#d8eac4d2dc0d7b6e11fa6e535332e0d3184f06b4"
-  integrity sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz#4345d81a9a46a6486e24d069469f13e60445c05d"
+  integrity sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==
   dependencies:
-    "@babel/types" "^7.25.9"
+    "@babel/types" "^7.27.1"
 
-"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz#75d92bb8d8d51301c0d49e52a65c9a7fe94514d8"
-  integrity sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==
+"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
+  integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
   dependencies:
-    "@babel/compat-data" "^7.26.5"
-    "@babel/helper-validator-option" "^7.25.9"
+    "@babel/compat-data" "^7.27.2"
+    "@babel/helper-validator-option" "^7.27.1"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz#7644147706bb90ff613297d49ed5266bde729f83"
-  integrity sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz#5bee4262a6ea5ddc852d0806199eb17ca3de9281"
+  integrity sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-member-expression-to-functions" "^7.25.9"
-    "@babel/helper-optimise-call-expression" "^7.25.9"
-    "@babel/helper-replace-supers" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-optimise-call-expression" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
     semver "^6.3.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.25.9":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz#5169756ecbe1d95f7866b90bb555b022595302a0"
-  integrity sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz#05b0882d97ba1d4d03519e4bce615d70afa18c53"
+  integrity sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
     regexpu-core "^6.2.0"
     semver "^6.3.1"
 
-"@babel/helper-define-polyfill-provider@^0.6.2", "@babel/helper-define-polyfill-provider@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz#f4f2792fae2ef382074bc2d713522cf24e6ddb21"
-  integrity sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==
+"@babel/helper-define-polyfill-provider@^0.6.3", "@babel/helper-define-polyfill-provider@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz#15e8746368bfa671785f5926ff74b3064c291fab"
+  integrity sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==
   dependencies:
     "@babel/helper-compilation-targets" "^7.22.6"
     "@babel/helper-plugin-utils" "^7.22.5"
@@ -140,146 +140,146 @@
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
 
-"@babel/helper-member-expression-to-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
-  integrity sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==
+"@babel/helper-member-expression-to-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz#ea1211276be93e798ce19037da6f06fbb994fa44"
+  integrity sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==
   dependencies:
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
-  integrity sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==
+"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
+  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
   dependencies:
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
-  integrity sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==
+"@babel/helper-module-transforms@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz#e1663b8b71d2de948da5c4fb2a20ca4f3ec27a6f"
+  integrity sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==
   dependencies:
-    "@babel/helper-module-imports" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/helper-optimise-call-expression@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz#3324ae50bae7e2ab3c33f60c9a877b6a0146b54e"
-  integrity sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==
+"@babel/helper-optimise-call-expression@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz#c65221b61a643f3e62705e5dd2b5f115e35f9200"
+  integrity sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==
   dependencies:
-    "@babel/types" "^7.25.9"
+    "@babel/types" "^7.27.1"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.26.5", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
-  integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
+  integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
 
-"@babel/helper-remap-async-to-generator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz#e53956ab3d5b9fb88be04b3e2f31b523afd34b92"
-  integrity sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==
+"@babel/helper-remap-async-to-generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz#4601d5c7ce2eb2aea58328d43725523fcd362ce6"
+  integrity sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-wrap-function" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-wrap-function" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/helper-replace-supers@^7.25.9":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz#6cb04e82ae291dae8e72335dfe438b0725f14c8d"
-  integrity sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==
+"@babel/helper-replace-supers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz#b1ed2d634ce3bdb730e4b52de30f8cccfd692bc0"
+  integrity sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.25.9"
-    "@babel/helper-optimise-call-expression" "^7.25.9"
-    "@babel/traverse" "^7.26.5"
+    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-optimise-call-expression" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/helper-skip-transparent-expression-wrappers@^7.20.0", "@babel/helper-skip-transparent-expression-wrappers@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz#0b2e1b62d560d6b1954893fd2b705dc17c91f0c9"
-  integrity sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==
+"@babel/helper-skip-transparent-expression-wrappers@^7.20.0", "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz#62bb91b3abba8c7f1fec0252d9dbea11b3ee7a56"
+  integrity sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==
   dependencies:
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/helper-string-parser@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
-  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
-  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
-"@babel/helper-validator-option@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
-  integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
+"@babel/helper-validator-option@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
+  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
-"@babel/helper-wrap-function@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz#d99dfd595312e6c894bd7d237470025c85eea9d0"
-  integrity sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==
+"@babel/helper-wrap-function@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz#b88285009c31427af318d4fe37651cd62a142409"
+  integrity sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==
   dependencies:
-    "@babel/template" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/template" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/helpers@^7.26.7":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.7.tgz#fd1d2a7c431b6e39290277aacfd8367857c576a4"
-  integrity sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==
+"@babel/helpers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.1.tgz#ffc27013038607cdba3288e692c3611c06a18aa4"
+  integrity sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==
   dependencies:
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.7"
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.25.9", "@babel/parser@^7.26.5", "@babel/parser@^7.26.7":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.7.tgz#e114cd099e5f7d17b05368678da0fb9f69b3385c"
-  integrity sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.27.1", "@babel/parser@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.2.tgz#577518bedb17a2ce4212afd052e01f7df0941127"
+  integrity sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==
   dependencies:
-    "@babel/types" "^7.26.7"
+    "@babel/types" "^7.27.1"
 
-"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz#cc2e53ebf0a0340777fff5ed521943e253b4d8fe"
-  integrity sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz#61dd8a8e61f7eb568268d1b5f129da3eee364bf9"
+  integrity sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz#af9e4fb63ccb8abcb92375b2fcfe36b60c774d30"
-  integrity sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==
+"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz#43f70a6d7efd52370eefbdf55ae03d91b293856d"
+  integrity sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz#e8dc26fcd616e6c5bf2bd0d5a2c151d4f92a9137"
-  integrity sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz#beb623bd573b8b6f3047bd04c32506adc3e58a72"
+  integrity sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz#807a667f9158acac6f6164b4beb85ad9ebc9e1d1"
-  integrity sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz#e134a5479eb2ba9c02714e8c1ebf1ec9076124fd"
+  integrity sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
-    "@babel/plugin-transform-optional-chaining" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/plugin-transform-optional-chaining" "^7.27.1"
 
-"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz#de7093f1e7deaf68eadd7cc6b07f2ab82543269e"
-  integrity sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz#bb1c25af34d75115ce229a1de7fa44bf8f955670"
+  integrity sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
 "@babel/plugin-proposal-class-properties@^7.16.0":
   version "7.18.6"
@@ -290,13 +290,13 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-proposal-decorators@^7.16.4":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.25.9.tgz#8680707f943d1a3da2cd66b948179920f097e254"
-  integrity sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.27.1.tgz#3686f424b2f8b2fee7579aa4df133a4f5244a596"
+  integrity sha512-DTxe4LBPrtFdsWzgpmbBKevg3e9PBy+dXRt19kSbucbZvL2uqtdqwwpluL1jfxYE0wIDTFp1nTy/q6gNLsxXrg==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/plugin-syntax-decorators" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-decorators" "^7.27.1"
 
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.16.0":
   version "7.18.6"
@@ -336,6 +336,16 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
+"@babel/plugin-proposal-private-property-in-object@^7.16.7":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
@@ -364,33 +374,33 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-decorators@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.25.9.tgz#986b4ca8b7b5df3f67cee889cedeffc2e2bf14b3"
-  integrity sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==
+"@babel/plugin-syntax-decorators@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz#ee7dd9590aeebc05f9d4c8c0560007b05979a63d"
+  integrity sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-syntax-flow@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz#96507595c21b45fccfc2bc758d5c45452e6164fa"
-  integrity sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==
+"@babel/plugin-syntax-flow@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz#6c83cf0d7d635b716827284b7ecd5aead9237662"
+  integrity sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-syntax-import-assertions@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz#620412405058efa56e4a564903b79355020f445f"
-  integrity sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==
+"@babel/plugin-syntax-import-assertions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz#88894aefd2b03b5ee6ad1562a7c8e1587496aecd"
+  integrity sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-syntax-import-attributes@^7.24.7", "@babel/plugin-syntax-import-attributes@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz#3b1412847699eea739b4f2602c74ce36f6b0b0f7"
-  integrity sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==
+"@babel/plugin-syntax-import-attributes@^7.24.7", "@babel/plugin-syntax-import-attributes@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz#34c017d54496f9b11b61474e7ea3dfd5563ffe07"
+  integrity sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-syntax-import-meta@^7.10.4":
   version "7.10.4"
@@ -406,12 +416,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz#a34313a178ea56f1951599b929c1ceacee719290"
-  integrity sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==
+"@babel/plugin-syntax-jsx@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz#2f9beb5eff30fa507c5532d107daac7b888fa34c"
+  integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -469,12 +479,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.25.9", "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz#67dda2b74da43727cf21d46cf9afef23f4365399"
-  integrity sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==
+"@babel/plugin-syntax-typescript@^7.27.1", "@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz#5147d29066a793450f220c63fa3a9431b7e6dd18"
+  integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
@@ -484,537 +494,537 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-arrow-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz#7821d4410bee5daaadbb4cdd9a6649704e176845"
-  integrity sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==
+"@babel/plugin-transform-arrow-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz#6e2061067ba3ab0266d834a9f94811196f2aba9a"
+  integrity sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-async-generator-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz#1b18530b077d18a407c494eb3d1d72da505283a2"
-  integrity sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==
+"@babel/plugin-transform-async-generator-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz#ca433df983d68e1375398e7ca71bf2a4f6fd89d7"
+  integrity sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-remap-async-to-generator" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-remap-async-to-generator" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/plugin-transform-async-to-generator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz#c80008dacae51482793e5a9c08b39a5be7e12d71"
-  integrity sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==
+"@babel/plugin-transform-async-to-generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz#9a93893b9379b39466c74474f55af03de78c66e7"
+  integrity sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==
   dependencies:
-    "@babel/helper-module-imports" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-remap-async-to-generator" "^7.25.9"
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-remap-async-to-generator" "^7.27.1"
 
-"@babel/plugin-transform-block-scoped-functions@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz#3dc4405d31ad1cbe45293aa57205a6e3b009d53e"
-  integrity sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==
+"@babel/plugin-transform-block-scoped-functions@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz#558a9d6e24cf72802dd3b62a4b51e0d62c0f57f9"
+  integrity sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.26.5"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-block-scoping@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz#c33665e46b06759c93687ca0f84395b80c0473a1"
-  integrity sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==
+"@babel/plugin-transform-block-scoping@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz#bc0dbe8ac6de5602981ba58ef68c6df8ef9bfbb3"
+  integrity sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-class-properties@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz#a8ce84fedb9ad512549984101fa84080a9f5f51f"
-  integrity sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==
+"@babel/plugin-transform-class-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz#dd40a6a370dfd49d32362ae206ddaf2bb082a925"
+  integrity sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-class-static-block@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz#6c8da219f4eb15cae9834ec4348ff8e9e09664a0"
-  integrity sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==
+"@babel/plugin-transform-class-static-block@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz#7e920d5625b25bbccd3061aefbcc05805ed56ce4"
+  integrity sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-classes@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz#7152457f7880b593a63ade8a861e6e26a4469f52"
-  integrity sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==
+"@babel/plugin-transform-classes@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz#03bb04bea2c7b2f711f0db7304a8da46a85cced4"
+  integrity sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-compilation-targets" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-replace-supers" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz#db36492c78460e534b8852b1d5befe3c923ef10b"
-  integrity sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==
+"@babel/plugin-transform-computed-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz#81662e78bf5e734a97982c2b7f0a793288ef3caa"
+  integrity sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/template" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/template" "^7.27.1"
 
-"@babel/plugin-transform-destructuring@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz#966ea2595c498224340883602d3cfd7a0c79cea1"
-  integrity sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==
+"@babel/plugin-transform-destructuring@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz#d5916ef7089cb254df0418ae524533c1b72ba656"
+  integrity sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-dotall-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz#bad7945dd07734ca52fe3ad4e872b40ed09bb09a"
-  integrity sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==
+"@babel/plugin-transform-dotall-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz#aa6821de864c528b1fecf286f0a174e38e826f4d"
+  integrity sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-duplicate-keys@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz#8850ddf57dce2aebb4394bb434a7598031059e6d"
-  integrity sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==
+"@babel/plugin-transform-duplicate-keys@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz#f1fbf628ece18e12e7b32b175940e68358f546d1"
+  integrity sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz#6f7259b4de127721a08f1e5165b852fcaa696d31"
-  integrity sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz#5043854ca620a94149372e69030ff8cb6a9eb0ec"
+  integrity sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-dynamic-import@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz#23e917de63ed23c6600c5dd06d94669dce79f7b8"
-  integrity sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==
+"@babel/plugin-transform-dynamic-import@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz#4c78f35552ac0e06aa1f6e3c573d67695e8af5a4"
+  integrity sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-exponentiation-operator@^7.26.3":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz#e29f01b6de302c7c2c794277a48f04a9ca7f03bc"
-  integrity sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==
+"@babel/plugin-transform-exponentiation-operator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz#fc497b12d8277e559747f5a3ed868dd8064f83e1"
+  integrity sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-export-namespace-from@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz#90745fe55053394f554e40584cda81f2c8a402a2"
-  integrity sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==
+"@babel/plugin-transform-export-namespace-from@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz#71ca69d3471edd6daa711cf4dfc3400415df9c23"
+  integrity sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-flow-strip-types@^7.16.0":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz#2904c85a814e7abb1f4850b8baf4f07d0a2389d4"
-  integrity sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz#5def3e1e7730f008d683144fb79b724f92c5cdf9"
+  integrity sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.26.5"
-    "@babel/plugin-syntax-flow" "^7.26.0"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-flow" "^7.27.1"
 
-"@babel/plugin-transform-for-of@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz#4bdc7d42a213397905d89f02350c5267866d5755"
-  integrity sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==
+"@babel/plugin-transform-for-of@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz#bc24f7080e9ff721b63a70ac7b2564ca15b6c40a"
+  integrity sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
-"@babel/plugin-transform-function-name@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz#939d956e68a606661005bfd550c4fc2ef95f7b97"
-  integrity sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==
+"@babel/plugin-transform-function-name@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz#4d0bf307720e4dce6d7c30fcb1fd6ca77bdeb3a7"
+  integrity sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/plugin-transform-json-strings@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz#c86db407cb827cded902a90c707d2781aaa89660"
-  integrity sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==
+"@babel/plugin-transform-json-strings@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz#a2e0ce6ef256376bd527f290da023983527a4f4c"
+  integrity sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz#1a1c6b4d4aa59bc4cad5b6b3a223a0abd685c9de"
-  integrity sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==
+"@babel/plugin-transform-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz#baaefa4d10a1d4206f9dcdda50d7d5827bb70b24"
+  integrity sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-logical-assignment-operators@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz#b19441a8c39a2fda0902900b306ea05ae1055db7"
-  integrity sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==
+"@babel/plugin-transform-logical-assignment-operators@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz#890cb20e0270e0e5bebe3f025b434841c32d5baa"
+  integrity sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-member-expression-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz#63dff19763ea64a31f5e6c20957e6a25e41ed5de"
-  integrity sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==
+"@babel/plugin-transform-member-expression-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz#37b88ba594d852418e99536f5612f795f23aeaf9"
+  integrity sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-modules-amd@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz#49ba478f2295101544abd794486cd3088dddb6c5"
-  integrity sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==
+"@babel/plugin-transform-modules-amd@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz#a4145f9d87c2291fe2d05f994b65dba4e3e7196f"
+  integrity sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==
   dependencies:
-    "@babel/helper-module-transforms" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-modules-commonjs@^7.25.9", "@babel/plugin-transform-modules-commonjs@^7.26.3":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz#8f011d44b20d02c3de44d8850d971d8497f981fb"
-  integrity sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==
+"@babel/plugin-transform-modules-commonjs@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz#8e44ed37c2787ecc23bdc367f49977476614e832"
+  integrity sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.26.0"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-modules-systemjs@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz#8bd1b43836269e3d33307151a114bcf3ba6793f8"
-  integrity sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==
+"@babel/plugin-transform-modules-systemjs@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz#00e05b61863070d0f3292a00126c16c0e024c4ed"
+  integrity sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==
   dependencies:
-    "@babel/helper-module-transforms" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
-"@babel/plugin-transform-modules-umd@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz#6710079cdd7c694db36529a1e8411e49fcbf14c9"
-  integrity sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==
+"@babel/plugin-transform-modules-umd@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz#63f2cf4f6dc15debc12f694e44714863d34cd334"
+  integrity sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==
   dependencies:
-    "@babel/helper-module-transforms" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz#454990ae6cc22fd2a0fa60b3a2c6f63a38064e6a"
-  integrity sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz#f32b8f7818d8fc0cc46ee20a8ef75f071af976e1"
+  integrity sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-new-target@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz#42e61711294b105c248336dcb04b77054ea8becd"
-  integrity sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==
+"@babel/plugin-transform-new-target@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz#259c43939728cad1706ac17351b7e6a7bea1abeb"
+  integrity sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-nullish-coalescing-operator@^7.26.6":
-  version "7.26.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz#fbf6b3c92cb509e7b319ee46e3da89c5bedd31fe"
-  integrity sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==
+"@babel/plugin-transform-nullish-coalescing-operator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz#4f9d3153bf6782d73dd42785a9d22d03197bc91d"
+  integrity sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.26.5"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-numeric-separator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz#bfed75866261a8b643468b0ccfd275f2033214a1"
-  integrity sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==
+"@babel/plugin-transform-numeric-separator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz#614e0b15cc800e5997dadd9bd6ea524ed6c819c6"
+  integrity sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-object-rest-spread@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz#0203725025074164808bcf1a2cfa90c652c99f18"
-  integrity sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==
+"@babel/plugin-transform-object-rest-spread@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz#67f9ab822347aa2bcee91e8996763da79bdea973"
+  integrity sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/plugin-transform-parameters" "^7.25.9"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-transform-destructuring" "^7.27.1"
+    "@babel/plugin-transform-parameters" "^7.27.1"
 
-"@babel/plugin-transform-object-super@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz#385d5de135162933beb4a3d227a2b7e52bb4cf03"
-  integrity sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==
+"@babel/plugin-transform-object-super@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz#1c932cd27bf3874c43a5cac4f43ebf970c9871b5"
+  integrity sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-replace-supers" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.27.1"
 
-"@babel/plugin-transform-optional-catch-binding@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz#10e70d96d52bb1f10c5caaac59ac545ea2ba7ff3"
-  integrity sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==
+"@babel/plugin-transform-optional-catch-binding@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz#84c7341ebde35ccd36b137e9e45866825072a30c"
+  integrity sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-optional-chaining@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz#e142eb899d26ef715435f201ab6e139541eee7dd"
-  integrity sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==
+"@babel/plugin-transform-optional-chaining@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz#874ce3c4f06b7780592e946026eb76a32830454f"
+  integrity sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
-"@babel/plugin-transform-parameters@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz#b856842205b3e77e18b7a7a1b94958069c7ba257"
-  integrity sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==
+"@babel/plugin-transform-parameters@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz#80334b54b9b1ac5244155a0c8304a187a618d5a7"
+  integrity sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-private-methods@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz#847f4139263577526455d7d3223cd8bda51e3b57"
-  integrity sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==
+"@babel/plugin-transform-private-methods@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz#fdacbab1c5ed81ec70dfdbb8b213d65da148b6af"
+  integrity sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-private-property-in-object@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz#9c8b73e64e6cc3cbb2743633885a7dd2c385fe33"
-  integrity sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==
+"@babel/plugin-transform-private-property-in-object@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz#4dbbef283b5b2f01a21e81e299f76e35f900fb11"
+  integrity sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-property-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz#d72d588bd88b0dec8b62e36f6fda91cedfe28e3f"
-  integrity sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==
+"@babel/plugin-transform-property-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz#07eafd618800591e88073a0af1b940d9a42c6424"
+  integrity sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-react-constant-elements@^7.12.1":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.25.9.tgz#08a1de35a301929b60fdf2788a54b46cd8ecd0ef"
-  integrity sha512-Ncw2JFsJVuvfRsa2lSHiC55kETQVLSnsYGQ1JDDwkUeWGTL/8Tom8aLTnlqgoeuopWrbbGndrc9AlLYrIosrow==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.27.1.tgz#6c6b50424e749a6e48afd14cf7b92f98cb9383f9"
+  integrity sha512-edoidOjl/ZxvYo4lSBOQGDSyToYVkTAwyVoa2tkuYTSmjrB1+uAedoL5iROVLXkxH+vRgA7uP4tMg2pUJpZ3Ug==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-react-display-name@^7.16.0", "@babel/plugin-transform-react-display-name@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz#4b79746b59efa1f38c8695065a92a9f5afb24f7d"
-  integrity sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==
+"@babel/plugin-transform-react-display-name@^7.16.0", "@babel/plugin-transform-react-display-name@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz#43af31362d71f7848cfac0cbc212882b1a16e80f"
+  integrity sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-react-jsx-development@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz#8fd220a77dd139c07e25225a903b8be8c829e0d7"
-  integrity sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==
+"@babel/plugin-transform-react-jsx-development@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz#47ff95940e20a3a70e68ad3d4fcb657b647f6c98"
+  integrity sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==
   dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.25.9"
+    "@babel/plugin-transform-react-jsx" "^7.27.1"
 
-"@babel/plugin-transform-react-jsx@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz#06367940d8325b36edff5e2b9cbe782947ca4166"
-  integrity sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==
+"@babel/plugin-transform-react-jsx@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz#1023bc94b78b0a2d68c82b5e96aed573bcfb9db0"
+  integrity sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-module-imports" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/plugin-syntax-jsx" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/types" "^7.27.1"
 
-"@babel/plugin-transform-react-pure-annotations@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz#ea1c11b2f9dbb8e2d97025f43a3b5bc47e18ae62"
-  integrity sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==
+"@babel/plugin-transform-react-pure-annotations@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz#339f1ce355eae242e0649f232b1c68907c02e879"
+  integrity sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-regenerator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz#03a8a4670d6cebae95305ac6defac81ece77740b"
-  integrity sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==
+"@babel/plugin-transform-regenerator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz#0a471df9213416e44cd66bf67176b66f65768401"
+  integrity sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    regenerator-transform "^0.15.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-regexp-modifiers@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz#2f5837a5b5cd3842a919d8147e9903cc7455b850"
-  integrity sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==
+"@babel/plugin-transform-regexp-modifiers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz#df9ba5577c974e3f1449888b70b76169998a6d09"
+  integrity sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-reserved-words@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz#0398aed2f1f10ba3f78a93db219b27ef417fb9ce"
-  integrity sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==
+"@babel/plugin-transform-reserved-words@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz#40fba4878ccbd1c56605a4479a3a891ac0274bb4"
+  integrity sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-runtime@^7.16.4":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz#62723ea3f5b31ffbe676da9d6dae17138ae580ea"
-  integrity sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz#f9fbf71949a209eb26b3e60375b1d956937b8be9"
+  integrity sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==
   dependencies:
-    "@babel/helper-module-imports" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
     babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.10.6"
+    babel-plugin-polyfill-corejs3 "^0.11.0"
     babel-plugin-polyfill-regenerator "^0.6.1"
     semver "^6.3.1"
 
-"@babel/plugin-transform-shorthand-properties@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz#bb785e6091f99f826a95f9894fc16fde61c163f2"
-  integrity sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==
+"@babel/plugin-transform-shorthand-properties@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz#532abdacdec87bfee1e0ef8e2fcdee543fe32b90"
+  integrity sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-spread@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz#24a35153931b4ba3d13cec4a7748c21ab5514ef9"
-  integrity sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==
+"@babel/plugin-transform-spread@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz#1a264d5fc12750918f50e3fe3e24e437178abb08"
+  integrity sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
-"@babel/plugin-transform-sticky-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz#c7f02b944e986a417817b20ba2c504dfc1453d32"
-  integrity sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==
+"@babel/plugin-transform-sticky-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz#18984935d9d2296843a491d78a014939f7dcd280"
+  integrity sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-template-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz#6dbd4a24e8fad024df76d1fac6a03cf413f60fe1"
-  integrity sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==
+"@babel/plugin-transform-template-literals@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz#1a0eb35d8bb3e6efc06c9fd40eb0bcef548328b8"
+  integrity sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-typeof-symbol@^7.26.7":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz#d0e33acd9223744c1e857dbd6fa17bd0a3786937"
-  integrity sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==
+"@babel/plugin-transform-typeof-symbol@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz#70e966bb492e03509cf37eafa6dcc3051f844369"
+  integrity sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.26.5"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-typescript@^7.25.9":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.7.tgz#64339515ea3eff610160f62499c3ef437d0ac83d"
-  integrity sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==
+"@babel/plugin-transform-typescript@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz#d3bb65598bece03f773111e88cc4e8e5070f1140"
+  integrity sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.26.5"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
-    "@babel/plugin-syntax-typescript" "^7.25.9"
+    "@babel/helper-annotate-as-pure" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
 
-"@babel/plugin-transform-unicode-escapes@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz#a75ef3947ce15363fccaa38e2dd9bc70b2788b82"
-  integrity sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==
+"@babel/plugin-transform-unicode-escapes@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz#3e3143f8438aef842de28816ece58780190cf806"
+  integrity sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-unicode-property-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz#a901e96f2c1d071b0d1bb5dc0d3c880ce8f53dd3"
-  integrity sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==
+"@babel/plugin-transform-unicode-property-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz#bdfe2d3170c78c5691a3c3be934c8c0087525956"
+  integrity sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-unicode-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz#5eae747fe39eacf13a8bd006a4fb0b5d1fa5e9b1"
-  integrity sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==
+"@babel/plugin-transform-unicode-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz#25948f5c395db15f609028e370667ed8bae9af97"
+  integrity sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-unicode-sets-regex@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz#65114c17b4ffc20fa5b163c63c70c0d25621fabe"
-  integrity sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==
+"@babel/plugin-transform-unicode-sets-regex@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz#6ab706d10f801b5c72da8bb2548561fa04193cd1"
+  integrity sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.16.4":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.26.7.tgz#24d38e211f4570b8d806337035cc3ae798e0c36d"
-  integrity sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.27.2.tgz#106e6bfad92b591b1f6f76fd4cf13b7725a7bf9a"
+  integrity sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==
   dependencies:
-    "@babel/compat-data" "^7.26.5"
-    "@babel/helper-compilation-targets" "^7.26.5"
-    "@babel/helper-plugin-utils" "^7.26.5"
-    "@babel/helper-validator-option" "^7.25.9"
-    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.25.9"
-    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.25.9"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.25.9"
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.25.9"
-    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.25.9"
+    "@babel/compat-data" "^7.27.2"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.27.1"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.27.1"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.27.1"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.27.1"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.27.1"
     "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
-    "@babel/plugin-syntax-import-assertions" "^7.26.0"
-    "@babel/plugin-syntax-import-attributes" "^7.26.0"
+    "@babel/plugin-syntax-import-assertions" "^7.27.1"
+    "@babel/plugin-syntax-import-attributes" "^7.27.1"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
-    "@babel/plugin-transform-arrow-functions" "^7.25.9"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.9"
-    "@babel/plugin-transform-async-to-generator" "^7.25.9"
-    "@babel/plugin-transform-block-scoped-functions" "^7.26.5"
-    "@babel/plugin-transform-block-scoping" "^7.25.9"
-    "@babel/plugin-transform-class-properties" "^7.25.9"
-    "@babel/plugin-transform-class-static-block" "^7.26.0"
-    "@babel/plugin-transform-classes" "^7.25.9"
-    "@babel/plugin-transform-computed-properties" "^7.25.9"
-    "@babel/plugin-transform-destructuring" "^7.25.9"
-    "@babel/plugin-transform-dotall-regex" "^7.25.9"
-    "@babel/plugin-transform-duplicate-keys" "^7.25.9"
-    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.25.9"
-    "@babel/plugin-transform-dynamic-import" "^7.25.9"
-    "@babel/plugin-transform-exponentiation-operator" "^7.26.3"
-    "@babel/plugin-transform-export-namespace-from" "^7.25.9"
-    "@babel/plugin-transform-for-of" "^7.25.9"
-    "@babel/plugin-transform-function-name" "^7.25.9"
-    "@babel/plugin-transform-json-strings" "^7.25.9"
-    "@babel/plugin-transform-literals" "^7.25.9"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.25.9"
-    "@babel/plugin-transform-member-expression-literals" "^7.25.9"
-    "@babel/plugin-transform-modules-amd" "^7.25.9"
-    "@babel/plugin-transform-modules-commonjs" "^7.26.3"
-    "@babel/plugin-transform-modules-systemjs" "^7.25.9"
-    "@babel/plugin-transform-modules-umd" "^7.25.9"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.25.9"
-    "@babel/plugin-transform-new-target" "^7.25.9"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.26.6"
-    "@babel/plugin-transform-numeric-separator" "^7.25.9"
-    "@babel/plugin-transform-object-rest-spread" "^7.25.9"
-    "@babel/plugin-transform-object-super" "^7.25.9"
-    "@babel/plugin-transform-optional-catch-binding" "^7.25.9"
-    "@babel/plugin-transform-optional-chaining" "^7.25.9"
-    "@babel/plugin-transform-parameters" "^7.25.9"
-    "@babel/plugin-transform-private-methods" "^7.25.9"
-    "@babel/plugin-transform-private-property-in-object" "^7.25.9"
-    "@babel/plugin-transform-property-literals" "^7.25.9"
-    "@babel/plugin-transform-regenerator" "^7.25.9"
-    "@babel/plugin-transform-regexp-modifiers" "^7.26.0"
-    "@babel/plugin-transform-reserved-words" "^7.25.9"
-    "@babel/plugin-transform-shorthand-properties" "^7.25.9"
-    "@babel/plugin-transform-spread" "^7.25.9"
-    "@babel/plugin-transform-sticky-regex" "^7.25.9"
-    "@babel/plugin-transform-template-literals" "^7.25.9"
-    "@babel/plugin-transform-typeof-symbol" "^7.26.7"
-    "@babel/plugin-transform-unicode-escapes" "^7.25.9"
-    "@babel/plugin-transform-unicode-property-regex" "^7.25.9"
-    "@babel/plugin-transform-unicode-regex" "^7.25.9"
-    "@babel/plugin-transform-unicode-sets-regex" "^7.25.9"
+    "@babel/plugin-transform-arrow-functions" "^7.27.1"
+    "@babel/plugin-transform-async-generator-functions" "^7.27.1"
+    "@babel/plugin-transform-async-to-generator" "^7.27.1"
+    "@babel/plugin-transform-block-scoped-functions" "^7.27.1"
+    "@babel/plugin-transform-block-scoping" "^7.27.1"
+    "@babel/plugin-transform-class-properties" "^7.27.1"
+    "@babel/plugin-transform-class-static-block" "^7.27.1"
+    "@babel/plugin-transform-classes" "^7.27.1"
+    "@babel/plugin-transform-computed-properties" "^7.27.1"
+    "@babel/plugin-transform-destructuring" "^7.27.1"
+    "@babel/plugin-transform-dotall-regex" "^7.27.1"
+    "@babel/plugin-transform-duplicate-keys" "^7.27.1"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.27.1"
+    "@babel/plugin-transform-dynamic-import" "^7.27.1"
+    "@babel/plugin-transform-exponentiation-operator" "^7.27.1"
+    "@babel/plugin-transform-export-namespace-from" "^7.27.1"
+    "@babel/plugin-transform-for-of" "^7.27.1"
+    "@babel/plugin-transform-function-name" "^7.27.1"
+    "@babel/plugin-transform-json-strings" "^7.27.1"
+    "@babel/plugin-transform-literals" "^7.27.1"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.27.1"
+    "@babel/plugin-transform-member-expression-literals" "^7.27.1"
+    "@babel/plugin-transform-modules-amd" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-modules-systemjs" "^7.27.1"
+    "@babel/plugin-transform-modules-umd" "^7.27.1"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.27.1"
+    "@babel/plugin-transform-new-target" "^7.27.1"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.27.1"
+    "@babel/plugin-transform-numeric-separator" "^7.27.1"
+    "@babel/plugin-transform-object-rest-spread" "^7.27.2"
+    "@babel/plugin-transform-object-super" "^7.27.1"
+    "@babel/plugin-transform-optional-catch-binding" "^7.27.1"
+    "@babel/plugin-transform-optional-chaining" "^7.27.1"
+    "@babel/plugin-transform-parameters" "^7.27.1"
+    "@babel/plugin-transform-private-methods" "^7.27.1"
+    "@babel/plugin-transform-private-property-in-object" "^7.27.1"
+    "@babel/plugin-transform-property-literals" "^7.27.1"
+    "@babel/plugin-transform-regenerator" "^7.27.1"
+    "@babel/plugin-transform-regexp-modifiers" "^7.27.1"
+    "@babel/plugin-transform-reserved-words" "^7.27.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.27.1"
+    "@babel/plugin-transform-spread" "^7.27.1"
+    "@babel/plugin-transform-sticky-regex" "^7.27.1"
+    "@babel/plugin-transform-template-literals" "^7.27.1"
+    "@babel/plugin-transform-typeof-symbol" "^7.27.1"
+    "@babel/plugin-transform-unicode-escapes" "^7.27.1"
+    "@babel/plugin-transform-unicode-property-regex" "^7.27.1"
+    "@babel/plugin-transform-unicode-regex" "^7.27.1"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.27.1"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
     babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.10.6"
+    babel-plugin-polyfill-corejs3 "^0.11.0"
     babel-plugin-polyfill-regenerator "^0.6.1"
-    core-js-compat "^3.38.1"
+    core-js-compat "^3.40.0"
     semver "^6.3.1"
 
 "@babel/preset-modules@0.1.6-no-external-plugins":
@@ -1027,64 +1037,62 @@
     esutils "^2.0.2"
 
 "@babel/preset-react@^7.12.5", "@babel/preset-react@^7.16.0":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.26.3.tgz#7c5e028d623b4683c1f83a0bd4713b9100560caa"
-  integrity sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.27.1.tgz#86ea0a5ca3984663f744be2fd26cb6747c3fd0ec"
+  integrity sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-validator-option" "^7.25.9"
-    "@babel/plugin-transform-react-display-name" "^7.25.9"
-    "@babel/plugin-transform-react-jsx" "^7.25.9"
-    "@babel/plugin-transform-react-jsx-development" "^7.25.9"
-    "@babel/plugin-transform-react-pure-annotations" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-transform-react-display-name" "^7.27.1"
+    "@babel/plugin-transform-react-jsx" "^7.27.1"
+    "@babel/plugin-transform-react-jsx-development" "^7.27.1"
+    "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
 "@babel/preset-typescript@^7.16.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz#4a570f1b8d104a242d923957ffa1eaff142a106d"
-  integrity sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz#190742a6428d282306648a55b0529b561484f912"
+  integrity sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-validator-option" "^7.25.9"
-    "@babel/plugin-syntax-jsx" "^7.25.9"
-    "@babel/plugin-transform-modules-commonjs" "^7.25.9"
-    "@babel/plugin-transform-typescript" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-typescript" "^7.27.1"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.7.tgz#f4e7fe527cd710f8dc0618610b61b4b060c3c341"
-  integrity sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==
-  dependencies:
-    regenerator-runtime "^0.14.0"
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.9.2":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
+  integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
 
-"@babel/template@^7.25.9", "@babel/template@^7.3.3":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
-  integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
+"@babel/template@^7.27.1", "@babel/template@^7.3.3":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
+  integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
   dependencies:
-    "@babel/code-frame" "^7.25.9"
-    "@babel/parser" "^7.25.9"
-    "@babel/types" "^7.25.9"
+    "@babel/code-frame" "^7.27.1"
+    "@babel/parser" "^7.27.2"
+    "@babel/types" "^7.27.1"
 
-"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.7", "@babel/traverse@^7.7.2":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.7.tgz#99a0a136f6a75e7fb8b0a1ace421e0b25994b8bb"
-  integrity sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==
+"@babel/traverse@^7.27.1", "@babel/traverse@^7.7.2":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
+  integrity sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==
   dependencies:
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.7"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.7"
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.6", "@babel/types@^7.20.7", "@babel/types@^7.25.9", "@babel/types@^7.26.5", "@babel/types@^7.26.7", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.7.tgz#5e2b89c0768e874d4d061961f3a5a153d71dc17a"
-  integrity sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==
+"@babel/types@^7.0.0", "@babel/types@^7.12.6", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
+  integrity sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==
   dependencies:
-    "@babel/helper-string-parser" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1231,9 +1239,9 @@
     ajv-keywords "^3.4.1"
 
 "@electron/asar@^3.2.7":
-  version "3.2.18"
-  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.18.tgz#fa607f829209bab8b9e0ce6658d3fe81b2cba517"
-  integrity sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.4.1.tgz#4e9196a4b54fba18c56cd8d5cac67c5bdc588065"
+  integrity sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==
   dependencies:
     commander "^5.0.0"
     glob "^7.1.6"
@@ -1308,10 +1316,32 @@
     minimatch "^9.0.3"
     plist "^3.1.0"
 
-"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz#d1145bf2c20132d6400495d6df4bf59362fd9d56"
-  integrity sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==
+"@emnapi/core@^1.4.0":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"
+  integrity sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==
+  dependencies:
+    "@emnapi/wasi-threads" "1.0.2"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.0":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.4.3.tgz#c0564665c80dc81c448adac23f9dfbed6c838f7d"
+  integrity sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz#977f44f844eac7d6c138a415a123818c655f874c"
+  integrity sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
+  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
@@ -1320,19 +1350,24 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
   integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
 
-"@eslint/config-array@^0.19.0":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.19.2.tgz#3060b809e111abfc97adb0bb1172778b90cb46aa"
-  integrity sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==
+"@eslint/config-array@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.20.0.tgz#7a1232e82376712d3340012a2f561a2764d1988f"
+  integrity sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==
   dependencies:
     "@eslint/object-schema" "^2.1.6"
     debug "^4.3.1"
     minimatch "^3.1.2"
 
-"@eslint/core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.10.0.tgz#23727063c21b335f752dbb3a16450f6f9cbc9091"
-  integrity sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==
+"@eslint/config-helpers@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@eslint/config-helpers/-/config-helpers-0.2.2.tgz#3779f76b894de3a8ec4763b79660e6d54d5b1010"
+  integrity sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==
+
+"@eslint/core@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.13.0.tgz#bf02f209846d3bf996f9e8009db62df2739b458c"
+  integrity sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==
   dependencies:
     "@types/json-schema" "^7.0.15"
 
@@ -1351,10 +1386,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/eslintrc@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.2.0.tgz#57470ac4e2e283a6bf76044d63281196e370542c"
-  integrity sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==
+"@eslint/eslintrc@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz#e55f7f1dd400600dd066dbba349c4c0bac916964"
+  integrity sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -1371,22 +1406,22 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@eslint/js@9.19.0", "@eslint/js@^9.17.0":
-  version "9.19.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.19.0.tgz#51dbb140ed6b49d05adc0b171c41e1a8713b7789"
-  integrity sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==
+"@eslint/js@9.26.0", "@eslint/js@^9.26.0":
+  version "9.26.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.26.0.tgz#1e13126b67a3db15111d2dcc61f69a2acff70bd5"
+  integrity sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==
 
 "@eslint/object-schema@^2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.6.tgz#58369ab5b5b3ca117880c0f6c0b0f32f6950f24f"
   integrity sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==
 
-"@eslint/plugin-kit@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz#ee07372035539e7847ef834e3f5e7b79f09e3a81"
-  integrity sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==
+"@eslint/plugin-kit@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz#47488d8f8171b5d4613e833313f3ce708e3525f8"
+  integrity sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==
   dependencies:
-    "@eslint/core" "^0.10.0"
+    "@eslint/core" "^0.13.0"
     levn "^0.4.1"
 
 "@fortawesome/fontawesome-common-types@6.7.2":
@@ -1457,10 +1492,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.3.1.tgz#c72a5c76a9fbaf3488e231b13dc52c0da7bab42a"
   integrity sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==
 
-"@humanwhocodes/retry@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.1.tgz#9a96ce501bc62df46c4031fbd970e3cc6b10f07b"
-  integrity sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==
+"@humanwhocodes/retry@^0.4.2":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
+  integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -1796,6 +1831,31 @@
     lodash "^4.17.15"
     tmp-promise "^3.0.2"
 
+"@modelcontextprotocol/sdk@^1.8.0":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.11.3.tgz#0bcc7b2d74ac1f749d1a7632ec2d674fd7066543"
+  integrity sha512-rmOWVRUbUJD7iSvJugjUbFZshTAuJ48MXoZ80Osx1GM0K/H1w7rSEvmw8m6vdWxNASgtaHIhAgre4H/E9GJiYQ==
+  dependencies:
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    express "^5.0.1"
+    express-rate-limit "^7.5.0"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.23.8"
+    zod-to-json-schema "^3.24.1"
+
+"@napi-rs/wasm-runtime@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.9.tgz#7278122cf94f3b36d8170a8eee7d85356dfa6a96"
+  integrity sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==
+  dependencies:
+    "@emnapi/core" "^1.4.0"
+    "@emnapi/runtime" "^1.4.0"
+    "@tybys/wasm-util" "^0.9.0"
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
@@ -1845,10 +1905,15 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@pkgr/core@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.4.tgz#d897170a2b0ba51f78a099edccd968f7b103387c"
+  integrity sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
-  version "0.5.15"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz#f126be97c30b83ed777e2aeabd518bc592e6e7c4"
-  integrity sha512-LFWllMA55pzB9D34w/wXUCf8+c+IYKuJDgxiZ3qMhl64KRMBHYM1I3VdGaD2BV5FNPV2/S2596bppxHbv2ZydQ==
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.16.tgz#36795b3d5a967032a769977780f2dcc01f4e9c4a"
+  integrity sha512-kLQc9xz6QIqd2oIYyXRUiAp79kGpFBm3fEM9ahfG1HI0WI5gdZ2OVHWdmZYnwODt7ISck+QuQ6sBPrtvUBML7Q==
   dependencies:
     ansi-html "^0.0.9"
     core-js-pure "^3.23.3"
@@ -1901,9 +1966,9 @@
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
 "@rushstack/eslint-patch@^1.1.0":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz#3a1c12c959010a55c17d46b395ed3047b545c246"
-  integrity sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz#75dce8e972f90bba488e2b0cc677fb233aa357ab"
+  integrity sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -2134,6 +2199,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@tybys/wasm-util@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.9.0.tgz#3e75eb00604c8d6db470bf18c37b7d984a0e3355"
+  integrity sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/aria-query@^5.0.1":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
@@ -2151,9 +2223,9 @@
     "@types/babel__traverse" "*"
 
 "@types/babel__generator@*":
-  version "7.6.8"
-  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.8.tgz#f836c61f48b1346e7d2b0d93c6dacc5b9535d3ab"
-  integrity sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
   dependencies:
     "@babel/types" "^7.0.0"
 
@@ -2166,9 +2238,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.20.6.tgz#8dc9f0ae0f202c08d8d4dab648912c8d6038e3f7"
-  integrity sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.20.7.tgz#968cdc2366ec3da159f61166428ee40f370e56c2"
+  integrity sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==
   dependencies:
     "@babel/types" "^7.20.7"
 
@@ -2212,11 +2284,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
-  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
-
 "@types/debug@^4.1.6":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -2256,9 +2323,9 @@
     "@types/json-schema" "*"
 
 "@types/estree@*", "@types/estree@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
-  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
+  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -2286,13 +2353,12 @@
     "@types/send" "*"
 
 "@types/express@*":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.0.tgz#13a7d1f75295e90d19ed6e74cab3678488eaa96c"
-  integrity sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.1.tgz#138d741c6e5db8cc273bec5285cd6e9d0779fc9f"
+  integrity sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^5.0.0"
-    "@types/qs" "*"
     "@types/serve-static" "*"
 
 "@types/express@^4.17.13":
@@ -2335,9 +2401,9 @@
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
 "@types/http-proxy@^1.17.8":
-  version "1.17.15"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.15.tgz#12118141ce9775a6499ecb4c01d02f90fc839d36"
-  integrity sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==
+  version "1.17.16"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.16.tgz#dee360707b35b3cc85afcde89ffeebff7d7f9240"
+  integrity sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==
   dependencies:
     "@types/node" "*"
 
@@ -2417,17 +2483,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^22.10.5":
-  version "22.13.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
-  integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
+"@types/node@*", "@types/node@^22.10.5", "@types/node@^22.7.7":
+  version "22.15.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.18.tgz#2f8240f7e932f571c2d45f555ba0b6c3f7a75963"
+  integrity sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==
   dependencies:
-    undici-types "~6.20.0"
+    undici-types "~6.21.0"
 
 "@types/node@^20.9.0":
-  version "20.17.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.17.tgz#5cea2af2e271313742c14f418eaf5dcfa8ae2e3a"
-  integrity sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==
+  version "20.17.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.47.tgz#f9cb375993fffdae609c8e17d2b3dd8d3c4bfa14"
+  integrity sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==
   dependencies:
     undici-types "~6.19.2"
 
@@ -2470,14 +2536,14 @@
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/react-dom@^18.0.0":
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
-  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react@^18.0.0":
-  version "18.3.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
-  integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
+  version "18.3.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.21.tgz#ba9bdc8833ceaf2b5edabbbabfbf9a84040df89a"
+  integrity sha512-gXLBtmlcRJeT09/sI4PxVwyrku6SaNUj/6cMubjE6T6XdY1fDmBL7r0nX0jbSZPU/Xr0KuwLLZh6aOYY5d91Xw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2502,9 +2568,9 @@
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/semver@^7.3.12":
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
-  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.0.tgz#64c441bdae033b378b6eef7d0c3d77c329b9378e"
+  integrity sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==
 
 "@types/send@*":
   version "0.17.4"
@@ -2555,14 +2621,14 @@
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/verror@^1.10.3":
-  version "1.10.10"
-  resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.10.tgz#d5a4b56abac169bfbc8b23d291363a682e6fa087"
-  integrity sha512-l4MM0Jppn18hb9xmM6wwD1uTdShpf9Pn80aXTStnK1C94gtPvJcV2FrDmbOQUAQfJ1cKZHktkQUDwEqaAKXMMg==
+  version "1.10.11"
+  resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.11.tgz#d3d6b418978c8aa202d41e5bb3483227b6ecc1bb"
+  integrity sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==
 
 "@types/ws@^8.5.5":
-  version "8.5.14"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.14.tgz#93d44b268c9127d96026cf44353725dd9b6c3c21"
-  integrity sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
 
@@ -2592,20 +2658,20 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.23.0.tgz#7745f4e3e4a7ae5f6f73fefcd856fd6a074189b7"
-  integrity sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w==
+"@typescript-eslint/eslint-plugin@8.32.1", "@typescript-eslint/eslint-plugin@^8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz#9185b3eaa3b083d8318910e12d56c68b3c4f45b4"
+  integrity sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.23.0"
-    "@typescript-eslint/type-utils" "8.23.0"
-    "@typescript-eslint/utils" "8.23.0"
-    "@typescript-eslint/visitor-keys" "8.23.0"
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/type-utils" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
     graphemer "^1.4.0"
-    ignore "^5.3.1"
+    ignore "^7.0.0"
     natural-compare "^1.4.0"
-    ts-api-utils "^2.0.1"
+    ts-api-utils "^2.1.0"
 
 "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.62.0"
@@ -2630,15 +2696,15 @@
   dependencies:
     "@typescript-eslint/utils" "5.62.0"
 
-"@typescript-eslint/parser@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.23.0.tgz#57acb3b65fce48d12b70d119436e145842a30081"
-  integrity sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q==
+"@typescript-eslint/parser@8.32.1", "@typescript-eslint/parser@^8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.32.1.tgz#18b0e53315e0bc22b2619d398ae49a968370935e"
+  integrity sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.23.0"
-    "@typescript-eslint/types" "8.23.0"
-    "@typescript-eslint/typescript-estree" "8.23.0"
-    "@typescript-eslint/visitor-keys" "8.23.0"
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/typescript-estree" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
     debug "^4.3.4"
 
 "@typescript-eslint/parser@^5.5.0":
@@ -2659,13 +2725,13 @@
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/scope-manager@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.23.0.tgz#ee3bb7546421ca924b9b7a8b62a77d388193ddec"
-  integrity sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==
+"@typescript-eslint/scope-manager@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz#9a6bf5fb2c5380e14fe9d38ccac6e4bbe17e8afc"
+  integrity sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==
   dependencies:
-    "@typescript-eslint/types" "8.23.0"
-    "@typescript-eslint/visitor-keys" "8.23.0"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
 
 "@typescript-eslint/type-utils@5.62.0":
   version "5.62.0"
@@ -2677,25 +2743,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/type-utils@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.23.0.tgz#271e1eecece072d92679dfda5ccfceac3faa9f76"
-  integrity sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==
+"@typescript-eslint/type-utils@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz#b9292a45f69ecdb7db74d1696e57d1a89514d21e"
+  integrity sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.23.0"
-    "@typescript-eslint/utils" "8.23.0"
+    "@typescript-eslint/typescript-estree" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
     debug "^4.3.4"
-    ts-api-utils "^2.0.1"
+    ts-api-utils "^2.1.0"
 
 "@typescript-eslint/types@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
-"@typescript-eslint/types@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.23.0.tgz#3355f6bcc5ebab77ef6dcbbd1113ec0a683a234a"
-  integrity sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==
+"@typescript-eslint/types@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.32.1.tgz#b19fe4ac0dc08317bae0ce9ec1168123576c1d4b"
+  integrity sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==
 
 "@typescript-eslint/typescript-estree@5.62.0":
   version "5.62.0"
@@ -2710,19 +2776,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.23.0.tgz#f633ef08efa656e386bc44b045ffcf9537cc6924"
-  integrity sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==
+"@typescript-eslint/typescript-estree@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz#9023720ca4ecf4f59c275a05b5fed69b1276face"
+  integrity sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==
   dependencies:
-    "@typescript-eslint/types" "8.23.0"
-    "@typescript-eslint/visitor-keys" "8.23.0"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/visitor-keys" "8.32.1"
     debug "^4.3.4"
     fast-glob "^3.3.2"
     is-glob "^4.0.3"
     minimatch "^9.0.4"
     semver "^7.6.0"
-    ts-api-utils "^2.0.1"
+    ts-api-utils "^2.1.0"
 
 "@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.58.0":
   version "5.62.0"
@@ -2738,15 +2804,15 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/utils@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.23.0.tgz#b269cbdc77129fd6e0e600b168b5ef740a625554"
-  integrity sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==
+"@typescript-eslint/utils@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.32.1.tgz#4d6d5d29b9e519e9a85e9a74e9f7bdb58abe9704"
+  integrity sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==
   dependencies:
-    "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.23.0"
-    "@typescript-eslint/types" "8.23.0"
-    "@typescript-eslint/typescript-estree" "8.23.0"
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/scope-manager" "8.32.1"
+    "@typescript-eslint/types" "8.32.1"
+    "@typescript-eslint/typescript-estree" "8.32.1"
 
 "@typescript-eslint/visitor-keys@5.62.0":
   version "5.62.0"
@@ -2756,18 +2822,105 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@8.23.0":
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.23.0.tgz#40405fd26a61d23f5f4c2ed0f016a47074781df8"
-  integrity sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==
+"@typescript-eslint/visitor-keys@8.32.1":
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz#4321395cc55c2eb46036cbbb03e101994d11ddca"
+  integrity sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==
   dependencies:
-    "@typescript-eslint/types" "8.23.0"
+    "@typescript-eslint/types" "8.32.1"
     eslint-visitor-keys "^4.2.0"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@unrs/resolver-binding-darwin-arm64@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.2.tgz#12eed2bd9865d1f55bb79d76072330b6032441d7"
+  integrity sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg==
+
+"@unrs/resolver-binding-darwin-x64@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.2.tgz#97e0212a85c56e156a272628ec55da7aff992161"
+  integrity sha512-qhVa8ozu92C23Hsmv0BF4+5Dyyd5STT1FolV4whNgbY6mj3kA0qsrGPe35zNR3wAN7eFict3s4Rc2dDTPBTuFQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.2.tgz#07594a9d1d83e84b52908800459273ea00caf595"
+  integrity sha512-zKKdm2uMXqLFX6Ac7K5ElnnG5VIXbDlFWzg4WJ8CGUedJryM5A3cTgHuGMw1+P5ziV8CRhnSEgOnurTI4vpHpg==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.2.tgz#9ef6031bb1136ee7862a6f94a2a53c395d2b6fae"
+  integrity sha512-8N1z1TbPnHH+iDS/42GJ0bMPLiGK+cUqOhNbMKtWJ4oFGzqSJk/zoXFzcQkgtI63qMcUI7wW1tq2usZQSb2jxw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.2.tgz#24910379ab39da1b15d65b1a06b4bfb4c293ca0c"
+  integrity sha512-tjYzI9LcAXR9MYd9rO45m1s0B/6bJNuZ6jeOxo1pq1K6OBuRMMmfyvJYval3s9FPPGmrldYA3mi4gWDlWuTFGA==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.2.tgz#49b6a8fb8f42f7530f51bc2e60fc582daed31ffb"
+  integrity sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.2.tgz#3a9707a6afda534f30c8de8a5de6c193b1b6d164"
+  integrity sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.2.tgz#659831ff2bfe8157d806b69b6efe142265bf9f0f"
+  integrity sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.2.tgz#e75abebd53cdddb3d635f6efb7a5ef6e96695717"
+  integrity sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.2.tgz#e99b5316ee612b180aff5a7211717f3fc8c3e54e"
+  integrity sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.2.tgz#36646d5f60246f0eae650fc7bcd79b3cbf7dcff1"
+  integrity sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.2.tgz#e720adc2979702c62f4040de05c854f186268c27"
+  integrity sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==
+
+"@unrs/resolver-binding-linux-x64-musl@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.2.tgz#684e576557d20deb4ac8ea056dcbe79739ca2870"
+  integrity sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==
+
+"@unrs/resolver-binding-wasm32-wasi@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.2.tgz#5b138ce8d471f5d0c8d6bfab525c53b80ca734e0"
+  integrity sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.9"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.2.tgz#bd772db4e8a02c31161cf1dfa33852eb7ef22df6"
+  integrity sha512-gtYTh4/VREVSLA+gHrfbWxaMO/00y+34htY7XpioBTy56YN2eBjkPrY1ML1Zys89X3RJDKVaogzwxlM1qU7egg==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.2.tgz#a6955ccdc43e809a158c4fe2d54931d34c3f7b51"
+  integrity sha512-Ywv20XHvHTDRQs12jd3MY8X5C8KLjDbg/jyaal/QLKx3fAShhJyD4blEANInsjxW3P7isHx1Blt56iUDDJO3jg==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.2.tgz#7fd81d89e34a711d398ca87f6d5842735d49721e"
+  integrity sha512-friS8NEQfHaDbkThxopGk+LuE5v3iY0StruifjQEt7SLbA46OnfgMO15sOTkbpJkol6RB+1l1TYPXh0sCddpvA==
 
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
@@ -2915,6 +3068,14 @@ abbrev@^1.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 accepts@~1.3.4, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -2954,9 +3115,9 @@ acorn@^7.1.1:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.11.0, acorn@^8.14.0, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.8.2, acorn@^8.9.0:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
-  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
 address@^1.0.1, address@^1.1.2:
   version "1.2.2"
@@ -3234,16 +3395,17 @@ array.prototype.findlast@^1.2.5:
     es-shim-unscopables "^1.0.2"
 
 array.prototype.findlastindex@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz#8c35a755c72908719453f87145ca011e39334d0d"
-  integrity sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz#cfa1065c81dcb64e34557c9b81d012f6a421c564"
+  integrity sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==
   dependencies:
-    call-bind "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-abstract "^1.23.2"
+    es-abstract "^1.23.9"
     es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    es-shim-unscopables "^1.0.2"
+    es-object-atoms "^1.1.1"
+    es-shim-unscopables "^1.1.0"
 
 array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
   version "1.3.3"
@@ -3266,17 +3428,18 @@ array.prototype.flatmap@^1.3.2, array.prototype.flatmap@^1.3.3:
     es-shim-unscopables "^1.0.2"
 
 array.prototype.reduce@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/array.prototype.reduce/-/array.prototype.reduce-1.0.7.tgz#6aadc2f995af29cb887eb866d981dc85ab6f7dc7"
-  integrity sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz#42f97f5078daedca687d4463fd3c05cbfd83da57"
+  integrity sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==
   dependencies:
-    call-bind "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-abstract "^1.23.2"
+    es-abstract "^1.23.9"
     es-array-method-boxes-properly "^1.0.0"
     es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    is-string "^1.0.7"
+    es-object-atoms "^1.1.1"
+    is-string "^1.1.1"
 
 array.prototype.tosorted@^1.1.4:
   version "1.1.4"
@@ -3348,15 +3511,15 @@ at-least-node@^1.0.0:
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 autoprefixer@^10.4.12, autoprefixer@^10.4.13:
-  version "10.4.20"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
-  integrity sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==
+  version "10.4.21"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.21.tgz#77189468e7a8ad1d9a37fbc08efc9f480cf0a95d"
+  integrity sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==
   dependencies:
-    browserslist "^4.23.3"
-    caniuse-lite "^1.0.30001646"
+    browserslist "^4.24.4"
+    caniuse-lite "^1.0.30001702"
     fraction.js "^4.3.7"
     normalize-range "^0.1.2"
-    picocolors "^1.0.1"
+    picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
 
 available-typed-arrays@^1.0.7:
@@ -3367,9 +3530,9 @@ available-typed-arrays@^1.0.7:
     possible-typed-array-names "^1.0.0"
 
 axe-core@^4.10.0:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
-  integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+  version "4.10.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
+  integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -3436,28 +3599,28 @@ babel-plugin-named-asset-import@^0.3.8:
   integrity sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==
 
 babel-plugin-polyfill-corejs2@^0.4.10:
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz#ca55bbec8ab0edeeef3d7b8ffd75322e210879a9"
-  integrity sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz#7d445f0e0607ebc8fb6b01d7e8fb02069b91dd8b"
+  integrity sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==
   dependencies:
     "@babel/compat-data" "^7.22.6"
-    "@babel/helper-define-polyfill-provider" "^0.6.3"
+    "@babel/helper-define-polyfill-provider" "^0.6.4"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.10.6:
-  version "0.10.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz#2deda57caef50f59c525aeb4964d3b2f867710c7"
-  integrity sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.2"
-    core-js-compat "^3.38.0"
-
-babel-plugin-polyfill-regenerator@^0.6.1:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz#abeb1f3f1c762eace37587f42548b08b57789bc8"
-  integrity sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==
+babel-plugin-polyfill-corejs3@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz#4e4e182f1bb37c7ba62e2af81d8dd09df31344f6"
+  integrity sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.3"
+    core-js-compat "^3.40.0"
+
+babel-plugin-polyfill-regenerator@^0.6.1:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz#428c615d3c177292a22b4f93ed99e358d7906a9b"
+  integrity sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.6.4"
 
 babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
@@ -3494,9 +3657,9 @@ babel-preset-jest@^27.5.1:
     babel-preset-current-node-syntax "^1.0.0"
 
 babel-preset-react-app@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-10.0.1.tgz#ed6005a20a24f2c88521809fa9aea99903751584"
-  integrity sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-10.1.0.tgz#e367f223f6c27878e6cc28471d0d506a9ab9f96c"
+  integrity sha512-f9B1xMdnkCIqe+2dHrJsoQFRz7reChaAHE/65SdaykPklQqhme2WaC08oD3is77x9ff98/9EazAKFDZv5rFEQg==
   dependencies:
     "@babel/core" "^7.16.0"
     "@babel/plugin-proposal-class-properties" "^7.16.0"
@@ -3505,6 +3668,7 @@ babel-preset-react-app@^10.0.1:
     "@babel/plugin-proposal-numeric-separator" "^7.16.0"
     "@babel/plugin-proposal-optional-chaining" "^7.16.0"
     "@babel/plugin-proposal-private-methods" "^7.16.0"
+    "@babel/plugin-proposal-private-property-in-object" "^7.16.7"
     "@babel/plugin-transform-flow-strip-types" "^7.16.0"
     "@babel/plugin-transform-react-display-name" "^7.16.0"
     "@babel/plugin-transform-runtime" "^7.16.4"
@@ -3590,6 +3754,21 @@ body-parser@1.20.3:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+body-parser@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.0.tgz#f7a9656de305249a715b549b7b8fd1ab9dfddcfa"
+  integrity sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.0"
+    http-errors "^2.0.0"
+    iconv-lite "^0.6.3"
+    on-finished "^2.4.1"
+    qs "^6.14.0"
+    raw-body "^3.0.0"
+    type-is "^2.0.0"
+
 bonjour-service@^1.0.11:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.3.0.tgz#80d867430b5a0da64e82a8047fc1e355bdb71722"
@@ -3635,15 +3814,15 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.21.4, browserslist@^4.23.3, browserslist@^4.24.0, browserslist@^4.24.3:
-  version "4.24.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
-  integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
+browserslist@^4.0.0, browserslist@^4.18.1, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4:
+  version "4.24.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.5.tgz#aa0f5b8560fe81fde84c6dcb38f759bafba0e11b"
+  integrity sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==
   dependencies:
-    caniuse-lite "^1.0.30001688"
-    electron-to-chromium "^1.5.73"
+    caniuse-lite "^1.0.30001716"
+    electron-to-chromium "^1.5.149"
     node-releases "^2.0.19"
-    update-browserslist-db "^1.1.1"
+    update-browserslist-db "^1.1.3"
 
 bser@2.1.1:
   version "2.1.1"
@@ -3705,7 +3884,7 @@ builtin-modules@^3.1.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -3752,10 +3931,10 @@ cacheable-request@^7.0.2:
     normalize-url "^6.0.1"
     responselike "^2.0.0"
 
-call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz#32e5892e6361b29b0b545ba6f7763378daca2840"
-  integrity sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
@@ -3770,13 +3949,13 @@ call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.2"
 
-call-bound@^1.0.2, call-bound@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.3.tgz#41cfd032b593e39176a71533ab4f384aa04fd681"
-  integrity sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==
+call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
   dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    get-intrinsic "^1.2.6"
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -3816,10 +3995,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
-  version "1.0.30001697"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz#040bbbb54463c4b4b3377c716b34a322d16e6fc7"
-  integrity sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001716:
+  version "1.0.30001718"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
+  integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -4095,9 +4274,9 @@ compressible@~2.0.18:
     mime-db ">= 1.43.0 < 2"
 
 compression@^1.7.4:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.5.tgz#fdd256c0a642e39e314c478f6c2cd654edd74c93"
-  integrity sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.0.tgz#09420efc96e11a0f44f3a558de59e321364180f7"
+  integrity sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==
   dependencies:
     bytes "3.1.2"
     compressible "~2.0.18"
@@ -4142,7 +4321,14 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4, content-type@~1.0.5:
+content-disposition@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.0.tgz#844426cb398f934caefcbb172200126bc7ceace2"
+  integrity sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@^1.0.5, content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -4162,32 +4348,42 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookie@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
-core-js-compat@^3.38.0, core-js-compat@^3.38.1:
-  version "3.40.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.40.0.tgz#7485912a5a4a4315c2fdb2cbdc623e6881c88b38"
-  integrity sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==
+core-js-compat@^3.40.0:
+  version "3.42.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.42.0.tgz#ce19c29706ee5806e26d3cb3c542d4cfc0ed51bb"
+  integrity sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==
   dependencies:
-    browserslist "^4.24.3"
+    browserslist "^4.24.4"
 
 core-js-pure@^3.23.3:
-  version "3.40.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.40.0.tgz#d9a019e9160f9b042eeb6abb92242680089d486e"
-  integrity sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==
+  version "3.42.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.42.0.tgz#e86c45a7f3bdcb608823e872f73d1ad9ddf0531d"
+  integrity sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==
 
 core-js@^3.19.2:
-  version "3.40.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.40.0.tgz#2773f6b06877d8eda102fc42f828176437062476"
-  integrity sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==
+  version "3.42.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.42.0.tgz#edbe91f78ac8cfb6df8d997e74d368a68082fe37"
+  integrity sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -4198,6 +4394,14 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig-typescript-loader@^1.0.0:
   version "1.0.9"
@@ -4248,7 +4452,7 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -4505,10 +4709,10 @@ debug@2.6.9, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
+  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
   dependencies:
     ms "^2.1.3"
 
@@ -4622,7 +4826,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-depd@2.0.0:
+depd@2.0.0, depd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -4638,9 +4842,9 @@ destroy@1.2.0:
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detect-libc@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
-  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.4.tgz#f04715b8ba815e53b4d8109655b6508a6865a7e8"
+  integrity sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -4845,9 +5049,9 @@ dotenv@^10.0.0:
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@^16.4.5:
-  version "16.4.7"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
-  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
+  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -4909,15 +5113,24 @@ electron-publish@25.1.7:
     lazy-val "^1.0.5"
     mime "^2.5.2"
 
-electron-to-chromium@^1.5.73:
-  version "1.5.95"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.95.tgz#c7819461af3cc64f467bd10bf020516e20682a2a"
-  integrity sha512-XNsZaQrgQX+BG37BRQv+E+HcOZlWhqYaDoVVNCws/WrYYdbGrkR1qCDJ2mviBF3flCs6/BTa4O7ANfFTFZk6Dg==
+electron-to-chromium@^1.5.149:
+  version "1.5.154"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.154.tgz#82430d66848efef703a3b643fb2a682bd08ae26b"
+  integrity sha512-G4VCFAyKbp1QJ+sWdXYIRYsPGvlV5sDACfCmoMFog3rjm1syLhI41WXm/swZypwCIWIm4IFLWzHY14joWMQ5Fw==
 
-electron@*, electron@^34.0.2:
-  version "34.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-34.1.1.tgz#1fc766e406401834fedb9747c4ca58671d9a1e46"
-  integrity sha512-1aDYk9Gsv1/fFeClMrxWGoVMl7uCUgl1pe26BiTnLXmAoqEXCa3f3sCKFWV+cuDzUjQGAZcpkWhGYTgWUSQrLA==
+electron@*:
+  version "36.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-36.2.0.tgz#05bb179eb4c5de0412fc6d49628abc949fd679c1"
+  integrity sha512-5yldoRjBKxPQfI0QMX+qq750o3Nl8N1SZnJqOPMq0gZ6rIJ+7y4ZLp808GrFwjfTm05TYgq3GSD8FGuKQZqwEw==
+  dependencies:
+    "@electron/get" "^2.0.0"
+    "@types/node" "^22.7.7"
+    extract-zip "^2.0.1"
+
+electron@^34.0.2:
+  version "34.5.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-34.5.6.tgz#b18f1973df9846ff41ab98c7f9a25c35d5ebf731"
+  integrity sha512-cmP0CDnWFwyZrzn72AXS9oJiOjNIRPgKpGO2ykz3Syo+9B2RJ9WQzxOKkpntcWE5/nRsyFkRUCMTgGo3uNvCxQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"
@@ -4948,15 +5161,15 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+encodeurl@^2.0.0, encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
-
-encodeurl@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
-  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
 encoding@^0.1.13:
   version "0.1.13"
@@ -5119,11 +5332,11 @@ es-iterator-helpers@^1.2.1:
     safe-array-concat "^1.1.3"
 
 es-module-lexer@^1.2.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
-  integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-es-object-atoms@^1.0.0:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
@@ -5140,12 +5353,12 @@ es-set-tostringtag@^2.0.3, es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-es-shim-unscopables@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz#1f6942e71ecc7835ed1c8a83006d8771a63a3763"
-  integrity sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==
+es-shim-unscopables@^1.0.2, es-shim-unscopables@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz#438df35520dac5d105f3943d927549ea3b00f4b5"
+  integrity sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==
   dependencies:
-    hasown "^2.0.0"
+    hasown "^2.0.2"
 
 es-to-primitive@^1.3.0:
   version "1.3.0"
@@ -5166,7 +5379,7 @@ escalade@^3.1.1, escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -5209,6 +5422,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^10.1.5:
+  version "10.1.5"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz#00c18d7225043b6fbce6a665697377998d453782"
+  integrity sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==
+
 eslint-config-react-app@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz#73ba3929978001c5c86274c017ea57eb5fa644b4"
@@ -5238,6 +5456,18 @@ eslint-import-resolver-node@^0.3.9:
     is-core-module "^2.13.0"
     resolve "^1.22.4"
 
+eslint-import-resolver-typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.3.4.tgz#3d04161698925b5dc9c297966442c2761a319de4"
+  integrity sha512-buzw5z5VtiQMysYLH9iW9BV04YyZebsw+gPi+c4FCjfS9i6COYOrEWw9t3m3wA9PFBfqcBCqWf32qrXLbwafDw==
+  dependencies:
+    debug "^4.4.0"
+    get-tsconfig "^4.10.0"
+    is-bun-module "^2.0.0"
+    stable-hash "^0.0.5"
+    tinyglobby "^0.2.13"
+    unrs-resolver "^1.6.3"
+
 eslint-module-utils@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz#fe4cfb948d61f49203d7b08871982b65b9af0b0b"
@@ -5253,7 +5483,7 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-import@^2.25.3:
+eslint-plugin-import@^2.25.3, eslint-plugin-import@^2.31.0:
   version "2.31.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz#310ce7e720ca1d9c0bb3f69adfd1c6bdd7d9e0e7"
   integrity sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==
@@ -5306,15 +5536,28 @@ eslint-plugin-jsx-a11y@^6.5.1:
     safe-regex-test "^1.0.3"
     string.prototype.includes "^2.0.1"
 
+eslint-plugin-prettier@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz#54d4748904e58eaf1ffe26c4bffa4986ca7f952b"
+  integrity sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+    synckit "^0.11.0"
+
 eslint-plugin-react-hooks@^4.3.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
-eslint-plugin-react@^7.27.1:
-  version "7.37.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz#1b6c80b6175b6ae4b26055ae4d55d04c414c7181"
-  integrity sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==
+eslint-plugin-react-hooks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz#1be0080901e6ac31ce7971beed3d3ec0a423d9e3"
+  integrity sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==
+
+eslint-plugin-react@^7.27.1, eslint-plugin-react@^7.37.5:
+  version "7.37.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz#2975511472bdda1b272b34d779335c9b0e877065"
+  integrity sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==
   dependencies:
     array-includes "^3.1.8"
     array.prototype.findlast "^1.2.5"
@@ -5326,7 +5569,7 @@ eslint-plugin-react@^7.27.1:
     hasown "^2.0.2"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
-    object.entries "^1.1.8"
+    object.entries "^1.1.9"
     object.fromentries "^2.0.8"
     object.values "^1.2.1"
     prop-types "^15.8.1"
@@ -5358,10 +5601,10 @@ eslint-scope@^7.2.2:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-scope@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.2.0.tgz#377aa6f1cb5dc7592cfd0b7f892fd0cf352ce442"
-  integrity sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==
+eslint-scope@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.3.0.tgz#10cd3a918ffdd722f5f3f7b5b83db9b23c87340d"
+  integrity sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -5436,21 +5679,23 @@ eslint@^8.3.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-eslint@^9.17.0:
-  version "9.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.19.0.tgz#ffa1d265fc4205e0f8464330d35f09e1d548b1bf"
-  integrity sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==
+eslint@^9.26.0:
+  version "9.26.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.26.0.tgz#978fe029adc2aceed28ab437bca876e83461c3b4"
+  integrity sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.12.1"
-    "@eslint/config-array" "^0.19.0"
-    "@eslint/core" "^0.10.0"
-    "@eslint/eslintrc" "^3.2.0"
-    "@eslint/js" "9.19.0"
-    "@eslint/plugin-kit" "^0.2.5"
+    "@eslint/config-array" "^0.20.0"
+    "@eslint/config-helpers" "^0.2.1"
+    "@eslint/core" "^0.13.0"
+    "@eslint/eslintrc" "^3.3.1"
+    "@eslint/js" "9.26.0"
+    "@eslint/plugin-kit" "^0.2.8"
     "@humanfs/node" "^0.16.6"
     "@humanwhocodes/module-importer" "^1.0.1"
-    "@humanwhocodes/retry" "^0.4.1"
+    "@humanwhocodes/retry" "^0.4.2"
+    "@modelcontextprotocol/sdk" "^1.8.0"
     "@types/estree" "^1.0.6"
     "@types/json-schema" "^7.0.15"
     ajv "^6.12.4"
@@ -5458,7 +5703,7 @@ eslint@^9.17.0:
     cross-spawn "^7.0.6"
     debug "^4.3.2"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^8.2.0"
+    eslint-scope "^8.3.0"
     eslint-visitor-keys "^4.2.0"
     espree "^10.3.0"
     esquery "^1.5.0"
@@ -5475,6 +5720,7 @@ eslint@^9.17.0:
     minimatch "^3.1.2"
     natural-compare "^1.4.0"
     optionator "^0.9.3"
+    zod "^3.24.2"
 
 espree@^10.0.1, espree@^10.3.0:
   version "10.3.0"
@@ -5538,7 +5784,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@~1.8.1:
+etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
@@ -5552,6 +5798,18 @@ events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+eventsource-parser@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.2.tgz#0fea1abd26eca8201099ff5212f6c4e7ca2fd5d3"
+  integrity sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -5599,6 +5857,11 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.2.tgz#a8f26adb96bf78e8cd8ad1037928d5e5c0679d91"
   integrity sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==
 
+express-rate-limit@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.0.tgz#6a67990a724b4fbbc69119419feef50c51e8b28f"
+  integrity sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==
+
 express@^4.17.3:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
@@ -5636,6 +5899,39 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.1.0.tgz#d31beaf715a0016f0d53f47d3b4d7acf28c75cc9"
+  integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.0"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
+
 extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
@@ -5656,6 +5952,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.3"
@@ -5684,9 +5985,9 @@ fast-uri@^3.0.1:
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fastq@^1.6.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.0.tgz#a82c6b7c2bb4e44766d865f07997785fecfdcb89"
-  integrity sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
+  integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
   dependencies:
     reusify "^1.0.4"
 
@@ -5710,6 +6011,11 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
+
+fdir@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
+  integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -5764,6 +6070,18 @@ finalhandler@1.3.1:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+finalhandler@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.0.tgz#72306373aa89d05a8242ed569ed86a1bff7c561f"
+  integrity sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
 
 find-cache-dir@^3.3.1:
   version "3.3.2"
@@ -5820,28 +6138,28 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
-  integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 follow-redirects@^1.0.0:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
-for-each@^0.3.3:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.4.tgz#814517ffc303d1399b2564d8165318e735d0341c"
-  integrity sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==
+for-each@^0.3.3, for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
 
 foreground-child@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
-  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
   dependencies:
-    cross-spawn "^7.0.0"
+    cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
 fork-ts-checker-webpack-plugin@^6.5.0:
@@ -5864,21 +6182,23 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     tapable "^1.0.0"
 
 form-data@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.2.tgz#83ad9ced7c03feaad97e293d6f6091011e1659c8"
-  integrity sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.3.tgz#349c8f2c9d8f8f0c879ee0eb7cc0d300018d6b09"
+  integrity sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.35"
 
 form-data@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
-  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
 
 forwarded@0.2.0:
@@ -5895,6 +6215,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
@@ -6001,17 +6326,17 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.7.tgz#dcfcb33d3272e15f445d15124bc0a216189b9044"
-  integrity sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
-    call-bind-apply-helpers "^1.0.1"
+    call-bind-apply-helpers "^1.0.2"
     es-define-property "^1.0.1"
     es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
+    es-object-atoms "^1.1.1"
     function-bind "^1.1.2"
-    get-proto "^1.0.0"
+    get-proto "^1.0.1"
     gopd "^1.2.0"
     has-symbols "^1.1.0"
     hasown "^2.0.2"
@@ -6055,6 +6380,13 @@ get-symbol-description@^1.1.0:
     call-bound "^1.0.3"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
+
+get-tsconfig@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.0.tgz#403a682b373a823612475a4c2928c7326fc0f6bb"
+  integrity sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -6155,10 +6487,10 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-globals@^15.14.0:
-  version "15.14.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-15.14.0.tgz#b8fd3a8941ff3b4d38f3319d433b61bbb482e73f"
-  integrity sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==
+globals@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-16.1.0.tgz#ee6ab147d41c64e9f2beaaaf66572d18df8e1e60"
+  integrity sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==
 
 globalthis@^1.0.1, globalthis@^1.0.4:
   version "1.0.4"
@@ -6275,7 +6607,7 @@ has-unicode@^2.0.1:
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
 
-hasown@^2.0.0, hasown@^2.0.2:
+hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -6317,9 +6649,9 @@ html-encoding-sniffer@^2.0.1:
     whatwg-encoding "^1.0.5"
 
 html-entities@^2.1.0, html-entities@^2.3.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.5.2.tgz#201a3cf95d3a15be7099521620d19dfb4f65359f"
-  integrity sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
+  integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -6361,16 +6693,16 @@ htmlparser2@^6.1.0:
     entities "^2.0.0"
 
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
-  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
   integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
 
-http-errors@2.0.0:
+http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
   integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
@@ -6392,9 +6724,9 @@ http-errors@~1.6.2:
     statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.5.1:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.9.tgz#b817b3ca0edea6236225000d795378707c169cec"
-  integrity sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.10.tgz#b3277bd6d7ed5588e20ea73bf724fcbe44609075"
+  integrity sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -6423,9 +6755,9 @@ http-proxy-agent@^7.0.0:
     debug "^4.3.4"
 
 http-proxy-middleware@^2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
-  integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz#e9e63d68afaa4eee3d147f39149ab84c0c2815ef"
+  integrity sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==
   dependencies:
     "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"
@@ -6493,7 +6825,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2, iconv-lite@^0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -6527,10 +6859,15 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-ignore@^5.2.0, ignore@^5.3.1:
+ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.4.tgz#a12c70d0f2607c5bf508fb65a40c75f037d7a078"
+  integrity sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==
 
 immer@^9.0.7:
   version "9.0.21"
@@ -6673,6 +7010,13 @@ is-boolean-object@^1.2.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
+is-bun-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-bun-module/-/is-bun-module-2.0.0.tgz#4d7859a87c0fcac950c95e666730e745eae8bddd"
+  integrity sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==
+  dependencies:
+    semver "^7.7.1"
+
 is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -6812,6 +7156,11 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-regex@^1.1.4, is-regex@^1.2.1:
   version "1.2.1"
@@ -7743,9 +8092,9 @@ language-tags@^1.0.9:
     language-subtag-registry "^0.3.20"
 
 launch-editor@^2.6.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.9.1.tgz#253f173bd441e342d4344b4dae58291abb425047"
-  integrity sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.10.0.tgz#5ca3edfcb9667df1e8721310f3a40f1127d4bc42"
+  integrity sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==
   dependencies:
     picocolors "^1.0.0"
     shell-quote "^1.8.1"
@@ -8025,6 +8374,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
@@ -8036,6 +8390,11 @@ merge-descriptors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -8065,17 +8424,24 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-"mime-db@>= 1.43.0 < 2":
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.53.0.tgz#3cb63cd820fc29896d9d4e8c32ab4fcd74ccb447"
-  integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
+"mime-db@>= 1.43.0 < 2", mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.0, mime-types@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.1.tgz#b1d94d6997a9b32fd69ebaed0db73de8acb519ce"
+  integrity sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -8262,9 +8628,14 @@ mz@^2.7.0:
     thenify-all "^1.0.0"
 
 nanoid@^3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
-  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+napi-postinstall@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/napi-postinstall/-/napi-postinstall-0.2.4.tgz#419697d0288cb524623e422f919624f22a5e4028"
+  integrity sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -8285,6 +8656,11 @@ negotiator@^0.6.3, negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -8313,9 +8689,9 @@ node-7z@^3.0.0:
     normalize-path "^3.0.0"
 
 node-abi@^3.45.0:
-  version "3.74.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.74.0.tgz#5bfb4424264eaeb91432d2adb9da23c63a301ed0"
-  integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
+  version "3.75.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.75.0.tgz#2f929a91a90a0d02b325c43731314802357ed764"
+  integrity sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==
   dependencies:
     semver "^7.3.5"
 
@@ -8325,9 +8701,9 @@ node-addon-api@^1.6.3:
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
 node-api-version@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.0.tgz#5177441da2b1046a4d4547ab9e0972eed7b1ac1d"
-  integrity sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.1.tgz#19bad54f6d65628cbee4e607a325e4488ace2de9"
+  integrity sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==
   dependencies:
     semver "^7.3.5"
 
@@ -8364,9 +8740,9 @@ node-releases@^2.0.19:
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
 nodemon@^3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.9.tgz#df502cdc3b120e1c3c0c6e4152349019efa7387b"
-  integrity sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.10.tgz#5015c5eb4fffcb24d98cf9454df14f4fecec9bc1"
+  integrity sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==
   dependencies:
     chokidar "^3.5.2"
     debug "^4"
@@ -8433,11 +8809,11 @@ nth-check@^2.0.1:
     boolbase "^1.0.0"
 
 nwsapi@^2.2.0:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.16.tgz#177760bba02c351df1d2644e220c31dfec8cdb43"
-  integrity sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.20.tgz#22e53253c61e7b0e7e93cef42c891154bcca11ef"
+  integrity sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -8477,14 +8853,15 @@ object.assign@^4.1.4, object.assign@^4.1.7:
     has-symbols "^1.1.0"
     object-keys "^1.1.1"
 
-object.entries@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.8.tgz#bffe6f282e01f4d17807204a24f8edd823599c41"
-  integrity sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==
+object.entries@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.9.tgz#e4770a6a1444afb61bd39f984018b5bede25f8b3"
+  integrity sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==
   dependencies:
-    call-bind "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
+    es-object-atoms "^1.1.1"
 
 object.fromentries@^2.0.8:
   version "2.0.8"
@@ -8533,7 +8910,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -8711,7 +9088,7 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.3, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -8762,6 +9139,11 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
+path-to-regexp@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
+  integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -8787,7 +9169,7 @@ picocolors@^0.2.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
   integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
 
-picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -8797,15 +9179,25 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatc
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 pirates@^4.0.1, pirates@^4.0.4:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
-  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
+  integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkce-challenge@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz#c3a405cb49e272094a38e890a2b51da0228c4d97"
+  integrity sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==
 
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
@@ -8838,9 +9230,9 @@ plist@^3.0.4, plist@^3.0.5, plist@^3.1.0:
     xmlbuilder "^15.1.1"
 
 possible-typed-array-names@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
-  integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
+  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
 postcss-attribute-case-insensitive@^5.0.2:
   version "5.0.2"
@@ -9358,9 +9750,9 @@ postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.4, postcss-selecto
     util-deprecate "^1.0.2"
 
 postcss-selector-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz#41bd8b56f177c093ca49435f65731befe25d6b9c"
-  integrity sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz#4d6af97eba65d73bc4d84bcb343e865d7dd16262"
+  integrity sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -9394,9 +9786,9 @@ postcss@^7.0.35:
     source-map "^0.6.1"
 
 postcss@^8.3.5, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
-  integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
+  integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
   dependencies:
     nanoid "^3.3.8"
     picocolors "^1.1.1"
@@ -9411,6 +9803,18 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
@@ -9500,7 +9904,7 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
@@ -9544,6 +9948,13 @@ qs@6.13.0:
   integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
   dependencies:
     side-channel "^1.0.6"
+
+qs@^6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
+  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+  dependencies:
+    side-channel "^1.1.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -9594,6 +10005,16 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-body@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.0.tgz#25b3476f07a51600619dae3fe82ddc28a36e5e0f"
+  integrity sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.6.3"
+    unpipe "1.0.0"
+
 react-app-polyfill@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz#95221e0a9bd259e5ca6b177c7bb1cb6768f68fd7"
@@ -9637,16 +10058,16 @@ react-dev-utils@^12.0.1:
     text-table "^0.2.0"
 
 react-dom@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.0.0.tgz#43446f1f01c65a4cd7f7588083e686a6726cfb57"
-  integrity sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.1.0.tgz#133558deca37fa1d682708df8904b25186793623"
+  integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
   dependencies:
-    scheduler "^0.25.0"
+    scheduler "^0.26.0"
 
 react-error-overlay@^6.0.11:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.1.0.tgz#22b86256beb1c5856f08a9a228adb8121dd985f2"
+  integrity sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -9669,21 +10090,19 @@ react-refresh@^0.11.0:
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 react-router-dom@^7.1.1:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.1.5.tgz#6b706a5503c01d99c1af69336a7de2e21cadd339"
-  integrity sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.6.0.tgz#eadcede43856dc714fa3572a946fd7502775c017"
+  integrity sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==
   dependencies:
-    react-router "7.1.5"
+    react-router "7.6.0"
 
-react-router@7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.1.5.tgz#c9e19d329d9ce2215fdae844ab6b023b911094db"
-  integrity sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==
+react-router@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.6.0.tgz#e2d0872d7bea8df79465a8bba9a20c87c32ce995"
+  integrity sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==
   dependencies:
-    "@types/cookie" "^0.6.0"
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"
-    turbo-stream "2.4.0"
 
 react-scripts@5.0.1:
   version "5.0.1"
@@ -9741,9 +10160,9 @@ react-scripts@5.0.1:
     fsevents "^2.3.2"
 
 react@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.0.0.tgz#6e1969251b9f108870aa4bff37a0ce9ddfaaabdd"
-  integrity sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
+  integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
 
 read-binary-file-arch@^1.0.6:
   version "1.0.6"
@@ -9834,22 +10253,10 @@ regenerator-runtime@^0.13.9:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
-
-regenerator-transform@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.2.tgz#5bbae58b522098ebdf09bca2f83838929001c7a4"
-  integrity sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-
 regex-parser@^2.2.11:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.3.0.tgz#4bb61461b1a19b8b913f3960364bb57887f920ee"
-  integrity sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.3.1.tgz#ee3f70e50bdd81a221d505242cb9a9c275a2ad91"
+  integrity sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==
 
 regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.3:
   version "1.5.4"
@@ -9947,6 +10354,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve-url-loader@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz#d50d4ddc746bb10468443167acf800dcd6c3ad57"
@@ -10007,9 +10419,9 @@ retry@^0.13.1:
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
+  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
@@ -10046,6 +10458,17 @@ rollup@^2.43.1:
   integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
   optionalDependencies:
     fsevents "~2.3.2"
+
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -10134,10 +10557,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0.tgz#336cd9768e8cceebf52d3c80e3dcf5de23e7e015"
-  integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
+scheduler@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
+  integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
 
 schema-utils@2.7.0:
   version "2.7.0"
@@ -10157,7 +10580,7 @@ schema-utils@^2.6.5:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.0.0, schema-utils@^3.2.0:
+schema-utils@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -10166,10 +10589,10 @@ schema-utils@^3.0.0, schema-utils@^3.2.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.0.tgz#3b669f04f71ff2dfb5aba7ce2d5a9d79b35622c0"
-  integrity sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==
+schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0, schema-utils@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.2.tgz#0c10878bf4a73fd2b1dfd14b9462b26788c806ae"
+  integrity sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
     ajv "^8.9.0"
@@ -10200,9 +10623,9 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 send@0.19.0:
   version "0.19.0"
@@ -10222,6 +10645,23 @@ send@0.19.0:
     on-finished "2.4.1"
     range-parser "~1.2.1"
     statuses "2.0.1"
+
+send@^1.1.0, send@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.0.tgz#32a7554fb777b831dfa828370f773a3808d37212"
+  integrity sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==
+  dependencies:
+    debug "^4.3.5"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    mime-types "^3.0.1"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.1"
 
 serialize-error@^7.0.1:
   version "7.0.1"
@@ -10266,6 +10706,16 @@ serve-static@1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
+
+serve-static@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.0.tgz#9c02564ee259bdd2251b82d659a2e7e1938d66f9"
+  integrity sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -10447,9 +10897,9 @@ socks-proxy-agent@^7.0.0:
     socks "^2.6.2"
 
 socks@^2.6.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5"
-  integrity sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.4.tgz#07109755cdd4da03269bda4725baa061ab56d5cc"
+  integrity sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==
   dependencies:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
@@ -10543,6 +10993,11 @@ ssri@^9.0.0:
   dependencies:
     minipass "^3.1.1"
 
+stable-hash@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.5.tgz#94e8837aaeac5b4d0f631d2972adef2924b40269"
+  integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
+
 stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
@@ -10572,7 +11027,7 @@ static-eval@2.0.2:
   dependencies:
     escodegen "^1.8.1"
 
-statuses@2.0.1:
+statuses@2.0.1, statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
@@ -10891,6 +11346,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@^0.11.0:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.11.5.tgz#258b3185736512f7ef11a42d67c4f3ad49da1744"
+  integrity sha512-frqvfWyDA5VPVdrWfH24uM6SI/O8NLpVbIIJxb8t/a3YGsp4AW9CYgSKC0OaSEfexnp7Y1pVh2Y6IHO8ggGDmA==
+  dependencies:
+    "@pkgr/core" "^0.2.4"
+    tslib "^2.8.1"
+
 tailwindcss@^3.0.2:
   version "3.4.17"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.17.tgz#ae8406c0f96696a631c790768ff319d46d5e5a63"
@@ -10972,10 +11435,10 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.10:
-  version "5.3.11"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz#93c21f44ca86634257cac176f884f942b7ba3832"
-  integrity sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==
+terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.11:
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz#9031d48e57ab27567f02ace85c7d690db66c3e06"
+  integrity sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
@@ -10984,9 +11447,9 @@ terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.10:
     terser "^5.31.1"
 
 terser@^5.0.0, terser@^5.10.0, terser@^5.31.1:
-  version "5.38.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.38.1.tgz#a18d83c8acf3175e847ab0b66839f3c318167c58"
-  integrity sha512-GWANVlPM/ZfYzuPHjq0nxT+EbOEDDN3Jwhwdg1D8TU8oSkktp8w64Uq4auuGLxFSoNTRDncTq2hQHX1Ld9KHkA==
+  version "5.39.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.39.1.tgz#1c80e6bde2b362c6f9f3e79e295c228a3882d983"
+  integrity sha512-Mm6+uad0ZuDtcV8/4uOZQDQ8RuiC5Pu+iZRedJtF7yA/27sPL7d++In/AJKpWZlU3SYMPPkVfwetn6sgZ66pUA==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -11030,6 +11493,14 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tinyglobby@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
+  integrity sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==
+  dependencies:
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
 
 tmp-promise@^3.0.2:
   version "3.0.3"
@@ -11101,10 +11572,10 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-api-utils@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.0.1.tgz#660729385b625b939aaa58054f45c058f33f10cd"
-  integrity sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==
+ts-api-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
+  integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"
@@ -11131,12 +11602,13 @@ ts-node@^10.7.0:
     yn "3.1.1"
 
 tsc-alias@^1.8.10:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.10.tgz#279f9bf0dd8bc10fb27820393d4881db5a303938"
-  integrity sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==
+  version "1.8.16"
+  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.16.tgz#dbc74e797071801c7284f1a478259de920f852d4"
+  integrity sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==
   dependencies:
     chokidar "^3.5.3"
     commander "^9.0.0"
+    get-tsconfig "^4.10.0"
     globby "^11.0.4"
     mylas "^2.1.9"
     normalize-path "^3.0.0"
@@ -11157,7 +11629,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.4.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -11168,11 +11640,6 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
-
-turbo-stream@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.0.tgz#1e4fca6725e90fa14ac4adb782f2d3759a5695f0"
-  integrity sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -11212,6 +11679,15 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-is@^2.0.0, type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -11274,23 +11750,18 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript-eslint@^8.19.0:
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.23.0.tgz#796deb48f040146b68fcc8cb07db68b87219a8d2"
-  integrity sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ==
+  version "8.32.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.32.1.tgz#1784335c781491be528ff84ab666e2f0f7591fd1"
+  integrity sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "8.23.0"
-    "@typescript-eslint/parser" "8.23.0"
-    "@typescript-eslint/utils" "8.23.0"
+    "@typescript-eslint/eslint-plugin" "8.32.1"
+    "@typescript-eslint/parser" "8.32.1"
+    "@typescript-eslint/utils" "8.32.1"
 
-typescript@^4.4.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@^5.4.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+typescript@^5.4.3, typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"
@@ -11317,10 +11788,10 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici-types@~6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
-  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
@@ -11391,15 +11862,40 @@ unquote@~1.1.1:
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==
 
+unrs-resolver@^1.6.3:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/unrs-resolver/-/unrs-resolver-1.7.2.tgz#a6844bcb9006020b58e718c5522a4f4552632b6b"
+  integrity sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==
+  dependencies:
+    napi-postinstall "^0.2.2"
+  optionalDependencies:
+    "@unrs/resolver-binding-darwin-arm64" "1.7.2"
+    "@unrs/resolver-binding-darwin-x64" "1.7.2"
+    "@unrs/resolver-binding-freebsd-x64" "1.7.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf" "1.7.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf" "1.7.2"
+    "@unrs/resolver-binding-linux-arm64-gnu" "1.7.2"
+    "@unrs/resolver-binding-linux-arm64-musl" "1.7.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu" "1.7.2"
+    "@unrs/resolver-binding-linux-riscv64-gnu" "1.7.2"
+    "@unrs/resolver-binding-linux-riscv64-musl" "1.7.2"
+    "@unrs/resolver-binding-linux-s390x-gnu" "1.7.2"
+    "@unrs/resolver-binding-linux-x64-gnu" "1.7.2"
+    "@unrs/resolver-binding-linux-x64-musl" "1.7.2"
+    "@unrs/resolver-binding-wasm32-wasi" "1.7.2"
+    "@unrs/resolver-binding-win32-arm64-msvc" "1.7.2"
+    "@unrs/resolver-binding-win32-ia32-msvc" "1.7.2"
+    "@unrs/resolver-binding-win32-x64-msvc" "1.7.2"
+
 upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-update-browserslist-db@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz#97e9c96ab0ae7bcac08e9ae5151d26e6bc6b5580"
-  integrity sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==
+update-browserslist-db@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz#348377dd245216f9e7060ff50b15a1b740b75420"
+  integrity sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
@@ -11468,7 +11964,7 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -11631,12 +12127,13 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.64.4:
-  version "5.97.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.97.1.tgz#972a8320a438b56ff0f1d94ade9e82eac155fa58"
-  integrity sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==
+  version "5.99.8"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.99.8.tgz#dd31a020b7c092d30c4c6d9a4edb95809e7f5946"
+  integrity sha512-lQ3CPiSTpfOnrEGeXDwoq5hIGzSjmwD72GdfVzF7CQAI7t47rJG9eDWvcEkEn3CUQymAElVvDg3YNTlCYj+qUQ==
   dependencies:
     "@types/eslint-scope" "^3.7.7"
     "@types/estree" "^1.0.6"
+    "@types/json-schema" "^7.0.15"
     "@webassemblyjs/ast" "^1.14.1"
     "@webassemblyjs/wasm-edit" "^1.14.1"
     "@webassemblyjs/wasm-parser" "^1.14.1"
@@ -11653,9 +12150,9 @@ webpack@^5.64.4:
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.2.0"
+    schema-utils "^4.3.2"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.10"
+    terser-webpack-plugin "^5.3.11"
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
@@ -11749,14 +12246,15 @@ which-collection@^1.0.1, which-collection@^1.0.2:
     is-weakset "^2.0.3"
 
 which-typed-array@^1.1.13, which-typed-array@^1.1.16, which-typed-array@^1.1.18:
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.18.tgz#df2389ebf3fbb246a71390e90730a9edb6ce17ad"
-  integrity sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.19.tgz#df03842e870b6b88e117524a4b364b6fc689f956"
+  integrity sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==
   dependencies:
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    for-each "^0.3.3"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
 
@@ -12008,9 +12506,9 @@ ws@^7.4.6:
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.13.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -12048,9 +12546,9 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.3.4:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
-  integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
 yargs-parser@^20.2.2:
   version "20.2.9"
@@ -12105,3 +12603,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod-to-json-schema@^3.24.1:
+  version "3.24.5"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz#d1095440b147fb7c2093812a53c54df8d5df50a3"
+  integrity sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==
+
+zod@^3.23.8, zod@^3.24.2:
+  version "3.24.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.4.tgz#e2e2cca5faaa012d76e527d0d36622e0a90c315f"
+  integrity sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==


### PR DESCRIPTION
This is part of the process in making this repo easy to contribute to in order to attract contributors.

The linting results are completely different, depending whether you run `yarn react:dev`or `yarn lint`. This is because craco uses a very simple internal eslint config.

Craco does not support the eslint flat config, so there is currently no way to point it at the config.

The best solution appears to be to disable craco's linting and create two sets of rules, one for the main process and one for the renderer process.

The rules I have chosen are a fairly common set for Electron Typescript React projects.

Of course, you may disagree with the rules I have chosen; just let me know... your project, your rules.

As part of this process I have also added a `.prettierrc` because eslint needs this in order for its Prettier plugins to work.